### PR TITLE
Session and request fixes for symfony 2.0.11

### DIFF
--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -482,7 +482,7 @@ class FormFlow {
 	}
 
 	public function isValid(FormInterface $form) {
-		if ($this->request->isMethod('POST') && !in_array($this->getRequestedTransition(), array(
+		if ('POST' == $this->request->getMethod() && !in_array($this->getRequestedTransition(), array(
 			self::TRANSITION_BACK,
 			self::TRANSITION_RESET,
 		))) {

--- a/Storage/SessionStorage.php
+++ b/Storage/SessionStorage.php
@@ -2,7 +2,7 @@
 
 namespace Craue\FormFlowBundle\Storage;
 
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session;
 
 /**
  * @author Toni Uebernickel <tuebernickel@gmail.com>
@@ -13,7 +13,7 @@ class SessionStorage implements StorageInterface {
 
 	protected $session;
 
-	public function __construct(SessionInterface $session) {
+	public function __construct(Session $session) {
 		$this->session = $session;
 	}
 


### PR DESCRIPTION
Symfony\Component\HttpFoundation\Request::isMethod() no longer exists.
Symfony\Component\HttpFoundation\Session\SessionInterface no longer exists.
