### PR TITLE
Add missing namespace import

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This approach makes it easy to turn an existing (usual) form into a form flow.
 // src/MyCompany/MyBundle/Form/CreateVehicleFlow.php
 use Craue\FormFlowBundle\Form\FormFlow;
 use Craue\FormFlowBundle\Form\FormFlowInterface;
+use Symfony\Component\Form\FormTypeInterface;
 
 class CreateVehicleFlow extends FormFlow {
 


### PR DESCRIPTION
Noticed that there was an undeclared namespace in the README, added it in for the benefit of copy/pasters like me :)
