### PR TITLE
Use request attributes bag

### DIFF
--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -382,7 +382,7 @@ abstract class FormFlow implements FormFlowInterface {
 				return intval($request->request->get($this->getFormStepKey(), $defaultStepNumber));
 			case 'GET':
 				return $this->allowDynamicStepNavigation ?
-						intval($request->query->get($this->dynamicStepNavigationParameter, $defaultStepNumber)) :
+						intval($request->get($this->dynamicStepNavigationParameter, $defaultStepNumber)) :
 						$defaultStepNumber;
 		}
 


### PR DESCRIPTION
It is better to fetch the step parameter from the request's attribute-bag instead of query directly. So it is more flexible to be used as Route-Parameter. f.e.:

``` xml
<route id="example_route" pattern="/my-form/{step}">
        <default key="_controller">example_controller:my-method</default>
        <default key="step">1</default>
</route>
```
