### PR TITLE
disallow invalid step config options

### DIFF
--- a/Form/Step.php
+++ b/Form/Step.php
@@ -20,30 +20,43 @@ class Step implements StepInterface {
 	/**
 	 * @var string|null
 	 */
-	protected $label;
+	protected $label = null;
 
 	/**
 	 * @var FormTypeInterface|string|null
 	 */
-	protected $type;
+	protected $type = null;
 
 	/**
 	 * @var callable|null
 	 */
-	private $skipFunction;
+	private $skipFunction = null;
 
 	/**
 	 * @var boolean|null Is only null if not yet evaluated.
 	 */
-	private $skipped = null;
+	private $skipped = false;
 
 	public static function createFromConfig($number, array $config) {
 		$step = new static();
 
 		$step->setNumber($number);
-		$step->setLabel(array_key_exists('label', $config) ? $config['label'] : null);
-		$step->setType(array_key_exists('type', $config) ? $config['type'] : null);
-		$step->setSkip(array_key_exists('skip', $config) ? $config['skip'] : false);
+
+		foreach ($config as $key => $value) {
+			switch ($key) {
+				case 'label':
+					$step->setLabel($value);
+					break;
+				case 'type':
+					$step->setType($value);
+					break;
+				case 'skip':
+					$step->setSkip($value);
+					break;
+				default:
+					throw new \InvalidArgumentException(sprintf('Invalid step config option "%s" given.', $key));
+			}
+		}
 
 		return $step;
 	}

--- a/Tests/Form/StepTest.php
+++ b/Tests/Form/StepTest.php
@@ -63,6 +63,16 @@ class StepTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage Invalid step config option "lable" given.
+	 */
+	public function testCreateFromConfig_invalidOptions() {
+		$step = Step::createFromConfig(1, array(
+			'lable' => 'label for step1',
+		));
+	}
+
+	/**
 	 * @dataProvider dataSetGetNumber
 	 */
 	public function testSetGetNumber($number) {


### PR DESCRIPTION
Check if there are unexpected keys returned from the `loadStepsConfig` implementation to detect typos in option names.

But there might be use cases where `loadStepsConfig` is abused to add more information about steps, which is then used in userland code. This change would prevent individually extending the step config. Thus I'm not sure if custom options should be allowed or not.

Refs #91. /cc @jgornick
