### PR TITLE
fixed the step list to avoid linking not yet accessible steps

### DIFF
--- a/Twig/Extension/FormFlowExtension.php
+++ b/Twig/Extension/FormFlowExtension.php
@@ -70,10 +70,28 @@ class FormFlowExtension extends \Twig_Extension {
 	 * @return boolean If the step can be linked to.
 	 */
 	public function isStepLinkable(FormFlow $flow, $stepNumber) {
-		return $flow->isAllowDynamicStepNavigation()
-				&& $stepNumber !== $flow->getCurrentStepNumber()
-				&& ($flow->isStepDone($stepNumber) || $flow->isStepDone($stepNumber - 1))
-				&& !$flow->isStepSkipped($stepNumber);
+		if (!$flow->isAllowDynamicStepNavigation()
+				|| $flow->getCurrentStepNumber() === $stepNumber
+				|| $flow->isStepSkipped($stepNumber)) {
+			return false;
+		}
+
+		$lastStepConsecutivelyDone = 0;
+		for ($i = $flow->getFirstStepNumber(); $i < $flow->getLastStepNumber(); ++$i) {
+			if ($flow->isStepDone($i)) {
+				$lastStepConsecutivelyDone = $i;
+			} else {
+				break;
+			}
+		}
+
+		$lastStepLinkable = $lastStepConsecutivelyDone + 1;
+
+		if ($stepNumber <= $lastStepLinkable) {
+			return true;
+		}
+
+		return false;
 	}
 
 }


### PR DESCRIPTION
#90 introduced a glitch when rendering the step list while containing skipped steps.

Consider a flow with 4 steps. Just going from step 1 to 2, the list would be:
1. linked (done)
2. not linked (current step)
3. not linked (skipped)
4. linked

So step 4 is linked mistakenly, which will be fixed by this PR.

/cc @jgornick
