### PR TITLE
remove options from method `createForm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - BC breaks (follow `UPGRADE-3.0.md` to upgrade):
   - [#101]: support for concurrent instances of the same flow
+  - [#104]: removed options from method `createForm`
   - removed the step field template
   - renamed property `step` to `stepNumber` and method `getStep` to `getStepNumber` within event classes
 - [#98]: add a validation error to the current form if a form of a previous step became invalid
@@ -11,6 +12,7 @@
 
 [#98]: https://github.com/craue/CraueFormFlowBundle/issues/98
 [#101]: https://github.com/craue/CraueFormFlowBundle/issues/101
+[#104]: https://github.com/craue/CraueFormFlowBundle/issues/104
 [#107]: https://github.com/craue/CraueFormFlowBundle/issues/107
 
 ## 2.1.4 (2013-12-05)

--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -661,8 +661,8 @@ abstract class FormFlow implements FormFlowInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function createForm(array $options = array()) {
-		return $this->createFormForStep($this->currentStepNumber, $options);
+	public function createForm() {
+		return $this->createFormForStep($this->currentStepNumber);
 	}
 
 	public function getFormOptions($step, array $options = array()) {

--- a/Form/FormFlowInterface.php
+++ b/Form/FormFlowInterface.php
@@ -80,10 +80,9 @@ interface FormFlowInterface {
 
 	/**
 	 * Creates the form for the current step.
-	 * @param array $options
 	 * @return FormInterface
 	 */
-	function createForm(array $options = array());
+	function createForm();
 
 	/**
 	 * @param integer $stepNumber

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -73,6 +73,35 @@ This version adds support for concurrent instances of the same flow, which requi
 	}
 	```
 
+## Removal of options from method `createForm`
+
+- Options cannot be passed to step forms using `createForm` anymore. You now have to use `getFormOptions` for that.
+
+	before:
+	```php
+	// in the action
+	$flow->bind($formData);
+	$form = $flow->createForm(array('i_want_it' => 'that_way'));
+	```
+
+	after:
+	```php
+	// in the action
+	$flow->bind($formData);
+	$formData->setIWantIt('that_way');
+	$form = $flow->createForm();
+
+	// in the flow class
+	public function getFormOptions($step, array $options = array()) {
+		$options = parent::getFormOptions($step, $options);
+
+		$formData = $this->getFormData();
+		$options['i_want_it'] = $formData->getIWantIt();
+
+		return $options;
+	}
+	```
+
 ## Events
 
 - Some methods have been renamed.


### PR DESCRIPTION
When calling `$flow->createForm($options)` in an action to create the form for the current (or next) step, these options will be passed to `createFormForStep` and the form will be created as expected. However, when applying saved data from previous steps, intermediate forms for those steps are created without passing these options to them, which may result in a differently built form.

To avoid WTFs caused by this behavior, it's cleaner to just remove the `$options` argument from `createForm` altogether and rely on `getFormOptions` entirely.
