### PR TITLE
let `getFormOptions` return an array for the `validation_groups` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@
 - [#98]: add a validation error to the current form if a form of a previous step became invalid
 - [#107]: added Czech translation
 - [#112]: improved Dutch translation
+- [#117]: method `getFormOptions` returns an array for the `validation_groups` option
 
 [#98]: https://github.com/craue/CraueFormFlowBundle/issues/98
 [#101]: https://github.com/craue/CraueFormFlowBundle/issues/101
 [#104]: https://github.com/craue/CraueFormFlowBundle/issues/104
 [#107]: https://github.com/craue/CraueFormFlowBundle/issues/107
 [#112]: https://github.com/craue/CraueFormFlowBundle/issues/112
+[#117]: https://github.com/craue/CraueFormFlowBundle/issues/117
 
 ## 2.1.4 (2013-12-05)
 

--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -667,7 +667,9 @@ abstract class FormFlow implements FormFlowInterface {
 
 	public function getFormOptions($step, array $options = array()) {
 		if (!array_key_exists('validation_groups', $options)) {
-			$options['validation_groups'] = $this->getValidationGroupPrefix() . $step;
+			$options['validation_groups'] = array(
+				$this->getValidationGroupPrefix() . $step,
+			);
 		}
 
 		$options['flow_instance'] = $this->getInstanceId();

--- a/Tests/Form/FormFlowTest.php
+++ b/Tests/Form/FormFlowTest.php
@@ -51,4 +51,35 @@ class FormFlowTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSame(1, $flowStub->getStep(1)->getNumber());
 	}
 
+	/**
+	 * Ensure that the "validation_groups" option can be overridden.
+	 */
+	public function testGetFormOptions_overrideValidationGroups() {
+		$flow = $this->getMockForAbstractClass('\Craue\FormFlowBundle\Form\FormFlow');
+
+		$options = $flow->getFormOptions(1, array(
+			'validation_groups' => 'Default',
+		));
+
+		$this->assertEquals('Default', $options['validation_groups']);
+	}
+
+	/**
+	 * Ensure that the generated default value for "validation_groups" is an array, which can be used to just add
+	 * other groups.
+	 */
+	public function testGetFormOptions_generatedValidationGroupIsArray() {
+		$flow = $this->getMockForAbstractClass('\Craue\FormFlowBundle\Form\FormFlow');
+
+		$flow
+			->expects($this->once())
+			->method('getName')
+			->will($this->returnValue('createTopic'))
+		;
+
+		$options = $flow->getFormOptions(1);
+
+		$this->assertEquals(array('flow_createTopic_step1'), $options['validation_groups']);
+	}
+
 }


### PR DESCRIPTION
This makes it easier to just add further validation groups by appending them to the returned value, eliminating the need to redefine the generated step-specific one. Added a test to avoid regressions. Refs #37.
