### PR TITLE
add generic form options to simplify passing options to all steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#107]: added Czech translation
 - [#112]: improved Dutch translation
 - [#117]: method `getFormOptions` returns an array for the `validation_groups` option
+- [#125]: added generic form options to simplify passing options to all steps
 
 [#98]: https://github.com/craue/CraueFormFlowBundle/issues/98
 [#101]: https://github.com/craue/CraueFormFlowBundle/issues/101
@@ -18,6 +19,7 @@
 [#107]: https://github.com/craue/CraueFormFlowBundle/issues/107
 [#112]: https://github.com/craue/CraueFormFlowBundle/issues/112
 [#117]: https://github.com/craue/CraueFormFlowBundle/issues/117
+[#125]: https://github.com/craue/CraueFormFlowBundle/issues/125
 
 ## 2.1.4 (2013-12-05)
 

--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -147,6 +147,12 @@ abstract class FormFlow implements FormFlowInterface {
 	private $stepForms = array();
 
 	/**
+	 * Options applied to forms of all steps.
+	 * @var array
+	 */
+	private $genericFormOptions = array();
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function setFormFactory(FormFactoryInterface $formFactory) {
@@ -356,6 +362,14 @@ abstract class FormFlow implements FormFlowInterface {
 
 	public function getDynamicStepNavigationStepParameter() {
 		return $this->dynamicStepNavigationStepParameter;
+	}
+
+	public function setGenericFormOptions(array $genericFormOptions) {
+		$this->genericFormOptions = $genericFormOptions;
+	}
+
+	public function getGenericFormOptions() {
+		return $this->genericFormOptions;
 	}
 
 	/**
@@ -666,6 +680,8 @@ abstract class FormFlow implements FormFlowInterface {
 	}
 
 	public function getFormOptions($step, array $options = array()) {
+		$options = array_merge($this->getGenericFormOptions(), $options);
+
 		if (!array_key_exists('validation_groups', $options)) {
 			$options['validation_groups'] = array(
 				$this->getValidationGroupPrefix() . $step,

--- a/README.md
+++ b/README.md
@@ -417,10 +417,25 @@ class CreateVehicleFlow extends FormFlow {
 }
 ```
 
+## Passing generic options to the form type
+
+To set options common for the form type(s) of all steps you can use method `setGenericFormOptions`:
+
+```php
+// in src/MyCompany/MyBundle/Controller/VehicleController.php
+public function createVehicleAction() {
+	// ...
+	$flow->bind($formData);
+	$flow->setGenericFormOptions(array('action' => 'targetUrl'));
+	$form = $flow->createForm();
+	// ...
+}
+```
+
 ## Passing step-based options to the form type
 
-If your form type needs options to build the form (e.g. conditional fields) you can override method `getFormOptions`
-of your flow class.
+To set options based on previous steps (e.g. to render fields depending on submitted data) you can override method
+`getFormOptions` of your flow class.
 Before you can use the options you have to define them in your form type class:
 
 ```php

--- a/Tests/Form/FormFlowTest.php
+++ b/Tests/Form/FormFlowTest.php
@@ -82,4 +82,19 @@ class FormFlowTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('flow_createTopic_step1'), $options['validation_groups']);
 	}
 
+	/**
+	 * Ensure that generic options are considered.
+	 */
+	public function testGetFormOptions_considerGenericOptions() {
+		$flow = $this->getMockForAbstractClass('\Craue\FormFlowBundle\Form\FormFlow');
+
+		$flow->setGenericFormOptions(array(
+			'action' => 'targetUrl',
+		));
+
+		$options = $flow->getFormOptions(1);
+
+		$this->assertEquals('targetUrl', $options['action']);
+	}
+
 }

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -75,31 +75,19 @@ This version adds support for concurrent instances of the same flow, which requi
 
 ## Removal of options from method `createForm`
 
-- Options cannot be passed to step forms using `createForm` anymore. You now have to use `getFormOptions` for that.
+- Options cannot be passed to step forms using `createForm` anymore. You can now use `setGenericFormOptions` for that.
 
 	before:
 	```php
-	// in the action
 	$flow->bind($formData);
-	$form = $flow->createForm(array('i_want_it' => 'that_way'));
+	$form = $flow->createForm(array('action' => 'targetUrl'));
 	```
 
 	after:
 	```php
-	// in the action
 	$flow->bind($formData);
-	$formData->setIWantIt('that_way');
+	$flow->setGenericFormOptions(array('action' => 'targetUrl'));
 	$form = $flow->createForm();
-
-	// in the flow class
-	public function getFormOptions($step, array $options = array()) {
-		$options = parent::getFormOptions($step, $options);
-
-		$formData = $this->getFormData();
-		$options['i_want_it'] = $formData->getIWantIt();
-
-		return $options;
-	}
 	```
 
 ## Events


### PR DESCRIPTION
As suggested by @birko in #121, this is meant to compensate the removal of options for `createForm` in #104 to easily allow passing options from actions to forms again.
