### PR TITLE
Replaced Deprecated Function Call

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ public function createVehicleAction() {
 			$form = $flow->createForm();
 		} else {
 			// flow finished
-			$em = $this->getDoctrine()->getEntityManager();
+			$em = $this->getDoctrine()->getManager();
 			$em->persist($formData);
 			$em->flush();
 


### PR DESCRIPTION
`getEntityManager` is deprecated since Symfony 2.1. `getManager` should be used instead.
