### PR TITLE
bump Symfony dependency to 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,6 @@ matrix:
     - php: hhvm
     - env: SYMFONY_VERSION="dev-master" MIN_STABILITY="dev"
   include:
-    - php: 5.3
-      env: SYMFONY_VERSION="2.1.*"
-    - php: 5.5
-      env: SYMFONY_VERSION="2.1.*"
-    - php: 5.5
-      env: SYMFONY_VERSION="2.2.*"
     - php: 5.5
       env: SYMFONY_VERSION="2.4.*" SENSIO_FRAMEWORK_EXTRA_BUNDLE_VERSION="3.*"
     - php: 5.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - BC breaks (follow `UPGRADE-3.0.md` to upgrade):
   - [#101]: support for concurrent instances of the same flow
   - [#104]: removed options from method `createForm`
+  - [#145]: bumped Symfony dependency to 2.3
   - removed the step field template
   - renamed property `step` to `stepNumber` and method `getStep` to `getStepNumber` within event classes
 - [#98]+[#143]: add a validation error to the current form if a form of a previous step became invalid
@@ -31,6 +32,7 @@
 [#134]: https://github.com/craue/CraueFormFlowBundle/issues/134
 [#142]: https://github.com/craue/CraueFormFlowBundle/issues/142
 [#143]: https://github.com/craue/CraueFormFlowBundle/issues/143
+[#145]: https://github.com/craue/CraueFormFlowBundle/issues/145
 [#146]: https://github.com/craue/CraueFormFlowBundle/issues/146
 
 ## 2.1.5 (2014-06-13)

--- a/EventListener/PreviousStepInvalidEventListener.php
+++ b/EventListener/PreviousStepInvalidEventListener.php
@@ -4,7 +4,6 @@ namespace Craue\FormFlowBundle\EventListener;
 
 use Craue\FormFlowBundle\Event\PreviousStepInvalidEvent;
 use Symfony\Component\Form\FormError;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -37,12 +36,7 @@ class PreviousStepInvalidEventListener {
 		$messageId = 'craueFormFlow.previousStepInvalid';
 		$messageParameters = array('%stepNumber%' => $stepNumber);
 
-		if (version_compare(Kernel::VERSION, '2.2', '>=')) {
-			return new FormError($this->translator->trans($messageId, $messageParameters, 'validators'));
-		}
-
-		// TODO remove as soon as Symfony >= 2.2 is required
-		return new FormError($messageId, $messageParameters);
+		return new FormError($this->translator->trans($messageId, $messageParameters, 'validators'));
 	}
 
 }

--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -17,7 +17,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * @author Christian Raue <christian.raue@gmail.com>
@@ -704,7 +703,7 @@ abstract class FormFlow implements FormFlowInterface {
 
 			if (array_key_exists($stepNumber, $stepData)) {
 				$stepForm = $this->createFormForStep($stepNumber, $options);
-				$stepForm->bind($stepData[$stepNumber]); // the form is validated here
+				$stepForm->submit($stepData[$stepNumber]); // the form is validated here
 
 				if ($this->revalidatePreviousSteps) {
 					$this->stepForms[$stepNumber] = $stepForm;
@@ -825,7 +824,7 @@ abstract class FormFlow implements FormFlowInterface {
 			self::TRANSITION_BACK,
 			self::TRANSITION_RESET,
 		))) {
-			$form->bind($request);
+			$form->submit($request);
 
 			if ($this->hasListeners(FormFlowEvents::POST_BIND_REQUEST)) {
 				$event = new PostBindRequestEvent($this, $form->getData(), $this->currentStepNumber);
@@ -1000,9 +999,7 @@ abstract class FormFlow implements FormFlowInterface {
 	}
 
 	protected function triggerDeprecationError($message) {
-		if (version_compare(Kernel::VERSION, '2.2', '>=')) {
-			trigger_error($message, E_USER_DEPRECATED);
-		}
+		trigger_error($message, E_USER_DEPRECATED);
 	}
 
 }

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ A live demo showcasing these features is available at http://craue.de/sf2playgro
 
 # Installation
 
-Please use tag 1.0.0 of this bundle if you need Symfony 2.0.x compatibility.
-
 ## Get the bundle
 
 Let Composer download and install the bundle by running

--- a/Tests/IntegrationTestBundle/Entity/RevalidatePreviousStepsData.php
+++ b/Tests/IntegrationTestBundle/Entity/RevalidatePreviousStepsData.php
@@ -3,6 +3,7 @@
 namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle\Entity;
 
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\ExecutionContextInterface;
 
 /**
  * @author Christian Raue <christian.raue@gmail.com>
@@ -19,8 +20,7 @@ class RevalidatePreviousStepsData {
 		self::$validationCalls = 0;
 	}
 
-	// TODO add Symfony\Component\Validator\ExecutionContextInterface type hint as soon as Symfony >= 2.2 is required
-	public function isDataValid($context) {
+	public function isDataValid(ExecutionContextInterface $context) {
 		// valid only on first call
 		if (++self::$validationCalls > 1) {
 			$context->addViolation('Take this!');

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
 	],
 	"require": {
 		"php": ">=5.3.2",
-		"symfony/form": "~2.1",
-		"symfony/http-kernel": "~2.1",
-		"symfony/translation": "~2.1",
-		"symfony/yaml": "~2.1"
+		"symfony/form": "~2.3",
+		"symfony/http-kernel": "~2.3",
+		"symfony/translation": "~2.3",
+		"symfony/yaml": "~2.3"
 	},
 	"require-dev": {
 		"doctrine/common": "~2.3",
 		"phpunit/phpunit": "~4.1",
-		"sensio/framework-extra-bundle": ">=2.1",
-		"symfony/symfony": "~2.1"
+		"sensio/framework-extra-bundle": ">=2.3",
+		"symfony/symfony": "~2.3"
 	},
 	"minimum-stability": "stable",
 	"prefer-stable": true,


### PR DESCRIPTION
Symfony 2.1 and 2.2 aren't maintained anymore, so it should be fine to move on. This allows removing some legacy code and reduces the number of Travis jobs.
