### PR TITLE
restructure data storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - [#101]: support for concurrent instances of the same flow
   - [#104]: removed options from method `createForm`
   - [#145]: bumped Symfony dependency to 2.3
+  - [#148]: restructured data storage
   - removed the step field template
   - renamed property `step` to `stepNumber` and method `getStep` to `getStepNumber` within event classes
 - [#98]+[#143]: add a validation error to the current form if a form of a previous step became invalid
@@ -34,6 +35,7 @@
 [#143]: https://github.com/craue/CraueFormFlowBundle/issues/143
 [#145]: https://github.com/craue/CraueFormFlowBundle/issues/145
 [#146]: https://github.com/craue/CraueFormFlowBundle/issues/146
+[#148]: https://github.com/craue/CraueFormFlowBundle/issues/148
 
 ## 2.1.6 (2015-02-02)
 

--- a/Form/FormFlowInterface.php
+++ b/Form/FormFlowInterface.php
@@ -3,7 +3,7 @@
 namespace Craue\FormFlowBundle\Form;
 
 use Craue\FormFlowBundle\Exception\InvalidTypeException;
-use Craue\FormFlowBundle\Storage\StorageInterface;
+use Craue\FormFlowBundle\Storage\DataManagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
@@ -32,14 +32,14 @@ interface FormFlowInterface {
 	function setRequest(Request $request = null);
 
 	/**
-	 * @param StorageInterface $storage
+	 * @param DataManagerInterface $dataManager
 	 */
-	function setStorage(StorageInterface $storage);
+	function setDataManager(DataManagerInterface $dataManager);
 
 	/**
-	 * @return StorageInterface
+	 * @return DataManagerInterface
 	 */
-	function getStorage();
+	function getDataManager();
 
 	/**
 	 * @param EventDispatcherInterface $eventDispatcher
@@ -75,6 +75,11 @@ interface FormFlowInterface {
 	 * @return string
 	 */
 	function getId();
+
+	/**
+	 * @return string
+	 */
+	function getInstanceId();
 
 	/**
 	 * Restores previously saved form data of all steps and determines the current step.

--- a/Resources/config/form_flow.xml
+++ b/Resources/config/form_flow.xml
@@ -23,15 +23,21 @@
 
 		<service id="craue.form.flow.storage" alias="craue.form.flow.storage_default" scope="request" />
 
+		<service id="craue.form.flow.data_manager_default" class="Craue\FormFlowBundle\Storage\DataManager" scope="request" public="false">
+			<argument type="service" id="craue.form.flow.storage" />
+		</service>
+
+		<service id="craue.form.flow.data_manager" alias="craue.form.flow.data_manager_default" scope="request" />
+
 		<service id="craue.form.flow" class="%craue.form.flow.class%" scope="request">
+			<call method="setDataManager">
+				<argument type="service" id="craue.form.flow.data_manager" />
+			</call>
 			<call method="setFormFactory">
 				<argument type="service" id="form.factory" />
 			</call>
 			<call method="setRequest">
 				<argument type="service" id="request" />
-			</call>
-			<call method="setStorage">
-				<argument type="service" id="craue.form.flow.storage" />
 			</call>
 			<call method="setEventDispatcher">
 				<argument type="service" id="event_dispatcher" on-invalid="ignore" />

--- a/Storage/DataManager.php
+++ b/Storage/DataManager.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Craue\FormFlowBundle\Storage;
+
+use Craue\FormFlowBundle\Form\FormFlowInterface;
+
+/**
+ * Manages data of flows and their steps.
+ *
+ * It uses the following data structure with {@link DataManagerInterface::STORAGE_ROOT} as name of the root element within the storage:
+ * <code>
+ * 	DataManagerInterface::STORAGE_ROOT => array(
+ * 		name of the flow => array(
+ * 			instance id of the flow => array(
+ * 				'data' => array() // the actual step data
+ * 			)
+ * 		)
+ * 	)
+ * </code>
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2015 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class DataManager implements ExtendedDataManagerInterface {
+
+	/**
+	 * @var string Key for the actual step data.
+	 */
+	const DATA_KEY = 'data';
+
+	/**
+	 * @var StorageInterface
+	 */
+	private $storage;
+
+	/**
+	 * @param StorageInterface $storage
+	 */
+	public function __construct(StorageInterface $storage) {
+		$this->storage = $storage;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getStorage() {
+		return $this->storage;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function save(FormFlowInterface $flow, array $data) {
+		// handle file uploads
+		if ($flow->isHandleFileUploads()) {
+			array_walk_recursive($data, function(&$value, $key) {
+				if (SerializableFile::isSupported($value)) {
+					$value = new SerializableFile($value);
+				}
+			});
+		}
+
+		// drop old data
+		$this->drop($flow);
+
+		// save new data
+		$savedFlows = $this->storage->get(DataManagerInterface::STORAGE_ROOT, array());
+
+		$savedFlows = array_merge_recursive($savedFlows, array(
+			$flow->getName() => array(
+				$flow->getInstanceId() => array(
+					self::DATA_KEY => $data,
+				),
+			),
+		));
+
+		$this->storage->set(DataManagerInterface::STORAGE_ROOT, $savedFlows);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function load(FormFlowInterface $flow) {
+		$data = array();
+
+		// try to find data for the given flow
+		$savedFlows = $this->storage->get(DataManagerInterface::STORAGE_ROOT, array());
+		if (isset($savedFlows[$flow->getName()][$flow->getInstanceId()][self::DATA_KEY])) {
+			$data = $savedFlows[$flow->getName()][$flow->getInstanceId()][self::DATA_KEY];
+		}
+
+		// handle file uploads
+		if ($flow->isHandleFileUploads()) {
+			$tempDir = $flow->getHandleFileUploadsTempDir();
+			array_walk_recursive($data, function(&$value, $key) use ($tempDir) {
+				if ($value instanceof SerializableFile) {
+					$value = $value->getAsFile($tempDir);
+				}
+			});
+		}
+
+		return $data;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function drop(FormFlowInterface $flow) {
+		$savedFlows = $this->storage->get(DataManagerInterface::STORAGE_ROOT, array());
+
+		// remove data for only this flow instance
+		if (isset($savedFlows[$flow->getName()][$flow->getInstanceId()])) {
+			unset($savedFlows[$flow->getName()][$flow->getInstanceId()]);
+		}
+
+		$this->storage->set(DataManagerInterface::STORAGE_ROOT, $savedFlows);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function listFlows() {
+		return array_keys($this->storage->get(DataManagerInterface::STORAGE_ROOT, array()));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function listInstances($name) {
+		$savedFlows = $this->storage->get(DataManagerInterface::STORAGE_ROOT, array());
+
+		if (array_key_exists($name, $savedFlows)) {
+			return array_keys($savedFlows[$name]);
+		}
+
+		return array();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function dropAll() {
+		$this->storage->remove(DataManagerInterface::STORAGE_ROOT);
+	}
+
+}

--- a/Storage/DataManagerInterface.php
+++ b/Storage/DataManagerInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Craue\FormFlowBundle\Storage;
+
+use Craue\FormFlowBundle\Form\FormFlowInterface;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2015 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+interface DataManagerInterface {
+
+	/**
+	 * @var string Key for storing data of all flows.
+	 */
+	const STORAGE_ROOT = 'craue_form_flow';
+
+	/**
+	 * @return StorageInterface
+	 */
+	function getStorage();
+
+	/**
+	 * Saves data of the given flow.
+	 * @param FormFlowInterface $flow
+	 * @param array $data
+	 */
+	function save(FormFlowInterface $flow, array $data);
+
+	/**
+	 * Loads data of the given flow.
+	 * @param FormFlowInterface $flow
+	 * @return array
+	 */
+	function load(FormFlowInterface $flow);
+
+	/**
+	 * Drops data of the given flow.
+	 * @param FormFlowInterface $flow
+	 */
+	function drop(FormFlowInterface $flow);
+
+}

--- a/Storage/ExtendedDataManagerInterface.php
+++ b/Storage/ExtendedDataManagerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Craue\FormFlowBundle\Storage;
+
+/**
+ * Extends the base {@link DataManagerInterface} by methods which may be used for custom flow management.
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2015 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+interface ExtendedDataManagerInterface extends DataManagerInterface {
+
+	/**
+	 * Note: This method may be used for custom flow management.
+	 * @return string[] Distinct names of flows (which may have data for more than one instance).
+	 */
+	function listFlows();
+
+	/**
+	 * Note: This method may be used for custom flow management.
+	 * @param $name Name of the flow.
+	 * @return string[] Instances of flows with the given name.
+	 */
+	function listInstances($name);
+
+	/**
+	 * Drops data of all flows.
+	 * Note: This method may be used for custom flow management.
+	 */
+	function dropAll();
+
+}

--- a/Tests/Form/FormFlowTest.php
+++ b/Tests/Form/FormFlowTest.php
@@ -215,13 +215,13 @@ class FormFlowTest extends UnitTestCase {
 		$this->assertSame($request, $flow->getRequest());
 	}
 
-	public function testSetGetStorage() {
+	public function testSetGetDataManager() {
 		$flow = $this->getMockedFlow();
 
-		$storage = $this->getMockedStorageInterface();
-		$flow->setStorage($storage);
+		$dataManager = $this->getMockedDataManagerInterface();
+		$flow->setDataManager($dataManager);
 
-		$this->assertSame($storage, $flow->getStorage());
+		$this->assertSame($dataManager, $flow->getDataManager());
 	}
 
 	public function testSetGetId() {
@@ -267,15 +267,6 @@ class FormFlowTest extends UnitTestCase {
 		$flow->setFormTransitionKey($formTransitionKey);
 
 		$this->assertEquals($formTransitionKey, $flow->getFormTransitionKey());
-	}
-
-	public function testSetGetStepDataKey() {
-		$flow = $this->getMockedFlow();
-
-		$stepDataKey = 'step-data-key';
-		$flow->setStepDataKey($stepDataKey);
-
-		$this->assertEquals($stepDataKey, $flow->getStepDataKey());
 	}
 
 	public function testSetGetValidationGroupPrefix() {

--- a/Tests/IntegrationTestBundle/Form/Demo1Flow.php
+++ b/Tests/IntegrationTestBundle/Form/Demo1Flow.php
@@ -89,7 +89,7 @@ class Demo1Flow extends FormFlow implements EventSubscriberInterface {
 	 * {@inheritDoc}
 	 */
 	public function bind($formData) {
-		$this->storage->set($this->getCalledEventsSessionKey(), array());
+		$this->dataManager->getStorage()->set($this->getCalledEventsSessionKey(), array());
 		parent::bind($formData);
 	}
 
@@ -98,9 +98,9 @@ class Demo1Flow extends FormFlow implements EventSubscriberInterface {
 	}
 
 	protected function logEventCall($name) {
-		$calledEvents = $this->storage->get($this->getCalledEventsSessionKey());
+		$calledEvents = $this->dataManager->getStorage()->get($this->getCalledEventsSessionKey());
 		$calledEvents[] = $name;
-		$this->storage->set($this->getCalledEventsSessionKey(), $calledEvents);
+		$this->dataManager->getStorage()->set($this->getCalledEventsSessionKey(), $calledEvents);
 	}
 
 	public function onPreBind(PreBindEvent $event) {

--- a/Tests/IntegrationTestBundle/Form/RevalidatePreviousStepsFlow.php
+++ b/Tests/IntegrationTestBundle/Form/RevalidatePreviousStepsFlow.php
@@ -71,7 +71,7 @@ class RevalidatePreviousStepsFlow extends FormFlow implements EventSubscriberInt
 	 * {@inheritDoc}
 	 */
 	public function bind($formData) {
-		$this->storage->set($this->getCalledEventsSessionKey(), array());
+		$this->dataManager->getStorage()->set($this->getCalledEventsSessionKey(), array());
 		parent::bind($formData);
 	}
 
@@ -80,9 +80,9 @@ class RevalidatePreviousStepsFlow extends FormFlow implements EventSubscriberInt
 	}
 
 	protected function logEventCall($name) {
-		$calledEvents = $this->storage->get($this->getCalledEventsSessionKey());
+		$calledEvents = $this->dataManager->getStorage()->get($this->getCalledEventsSessionKey());
 		$calledEvents[] = $name;
-		$this->storage->set($this->getCalledEventsSessionKey(), $calledEvents);
+		$this->dataManager->getStorage()->set($this->getCalledEventsSessionKey(), $calledEvents);
 	}
 
 	public function onPreviousStepInvalid(PreviousStepInvalidEvent $event) {

--- a/Tests/Resources/TemplateRenderingTest.php
+++ b/Tests/Resources/TemplateRenderingTest.php
@@ -3,6 +3,7 @@
 namespace Craue\FormFlowBundle\Tests\Form;
 
 use Craue\FormFlowBundle\Form\FormFlow;
+use Craue\FormFlowBundle\Storage\DataManager;
 use Craue\FormFlowBundle\Storage\SessionStorage;
 use Craue\FormFlowBundle\Tests\IntegrationTestCase;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -275,7 +276,7 @@ class TemplateRenderingTest extends IntegrationTestCase {
 		/* @var $flow \PHPUnit_Framework_MockObject_MockObject|FormFlow */
 		$flow = $this->getMock('\Craue\FormFlowBundle\Form\FormFlow', array_merge(array('getName', 'loadStepsConfig'), $stubbedMethods));
 
-		$flow->setStorage(new SessionStorage(new Session(new MockArraySessionStorage())));
+		$flow->setDataManager(new DataManager(new SessionStorage(new Session(new MockArraySessionStorage()))));
 
 		$flow
 			->expects($this->any())

--- a/Tests/Storage/DataManagerTest.php
+++ b/Tests/Storage/DataManagerTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Craue\FormFlowBundle\Tests\Storage;
+
+use Craue\FormFlowBundle\Form\FormFlow;
+use Craue\FormFlowBundle\Storage\DataManager;
+use Craue\FormFlowBundle\Storage\DataManagerInterface;
+use Craue\FormFlowBundle\Storage\ExtendedDataManagerInterface;
+use Craue\FormFlowBundle\Storage\SessionStorage;
+use Craue\FormFlowBundle\Storage\StorageInterface;
+use Craue\FormFlowBundle\Tests\UnitTestCase;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+/**
+ * @group unit
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2015 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class DataManagerTest extends UnitTestCase {
+
+	/**
+	 * @var StorageInterface
+	 */
+	protected $storage;
+
+	/**
+	 * @var ExtendedDataManagerInterface
+	 */
+	protected $dataManager;
+
+	protected $createLocationFlowName = 'createLocation';
+	protected $createLocationFlowInstanceId = '26xz98wx38';
+	protected $createLocationFlowData = array(
+		// step 1
+		array(
+			'country' => 'US',
+			'_token' => '81jaZU6lQD_oCV-BmTZSxAN3rORRQgAVEu4iZbsACRE',
+		),
+		// step 2
+		array(
+			'region' => 'US-TX',
+			'_token' => 'ytCzDJAGrpo7ToVKqU89IOIQ0sDW2LDeve_5X0x6Sy0',
+		),
+	);
+
+	protected $createVehicleFlowName = 'createVehicle';
+	protected $createVehicleFlowInstanceId = '3a03y1o9at';
+	protected $createVehicleFlowData = array(
+		// step 1
+		array(
+			'vehicle' => array(
+				'numberOfWheels' => '2',
+			),
+			'_token' => 'sGcKUDmMmeaLedFQhoDt2ULi_39hErh4ZqZN1qZDCjc',
+		),
+	);
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp() {
+		$this->storage = new SessionStorage(new Session(new MockArraySessionStorage()));
+		$this->dataManager = new DataManager($this->storage);
+	}
+
+	public function testGetStorage() {
+		$this->assertSame($this->storage, $this->dataManager->getStorage());
+	}
+
+	public function testSaveLoadDrop() {
+		// create two flows
+		$createLocationFlow = $this->getFlow($this->createLocationFlowName, $this->createLocationFlowInstanceId);
+		$createVehicleFlow = $this->getFlow($this->createVehicleFlowName, $this->createVehicleFlowInstanceId);
+
+		// save their data
+		$this->dataManager->save($createLocationFlow, $this->createLocationFlowData);
+		$this->dataManager->save($createVehicleFlow, $this->createVehicleFlowData);
+
+		// ensure their data has been saved correctly
+		$this->assertEquals($this->createLocationFlowData, $this->dataManager->load($createLocationFlow));
+		$this->assertEquals($this->createVehicleFlowData, $this->dataManager->load($createVehicleFlow));
+
+		// drop data for one of them
+		$this->dataManager->drop($createLocationFlow);
+
+		// ensure only data of the correct flow has been dropped
+		$this->assertEquals(array(), $this->dataManager->load($createLocationFlow));
+		$this->assertEquals($this->createVehicleFlowData, $this->dataManager->load($createVehicleFlow));
+	}
+
+	public function testSave_overwriteOldDate() {
+		// create a flow
+		$createLocationFlow = $this->getFlow($this->createLocationFlowName, $this->createLocationFlowInstanceId);
+
+		// save its data
+		$this->dataManager->save($createLocationFlow, $this->createLocationFlowData);
+
+		$newData = array('blah' => 'blah');
+
+		// save changed data
+		$this->dataManager->save($createLocationFlow, $newData);
+
+		// ensure its data has been overwritten correctly
+		$this->assertEquals($newData, $this->dataManager->load($createLocationFlow));
+	}
+
+	/**
+	 * Ensure that even without any data an array is returned.
+	 */
+	public function testLoad_emptyStorage() {
+		$createLocationFlow = $this->getFlow($this->createLocationFlowName, $this->createLocationFlowInstanceId);
+		$this->assertEquals(array(), $this->dataManager->load($createLocationFlow));
+	}
+
+	public function testListFlows() {
+		// create three flows
+		$createLocationFlow1 = $this->getFlow($this->createLocationFlowName, $this->createLocationFlowInstanceId);
+		$createLocationFlow2 = $this->getFlow($this->createLocationFlowName, 'other-instance');
+		$createVehicleFlow = $this->getFlow($this->createVehicleFlowName, $this->createVehicleFlowInstanceId);
+
+		// save their data
+		$this->dataManager->save($createLocationFlow1, $this->createLocationFlowData);
+		$this->dataManager->save($createLocationFlow2, $this->createLocationFlowData);
+		$this->dataManager->save($createVehicleFlow, $this->createVehicleFlowData);
+
+		// get names of all flows
+		$expectedResult = array(
+			$this->createLocationFlowName,
+			$this->createVehicleFlowName,
+		);
+		$this->assertEquals($expectedResult, $this->dataManager->listFlows());
+	}
+
+	/**
+	 * Ensure that even without any data an array is returned.
+	 */
+	public function testListFlows_emptyStorage() {
+		$this->assertEquals(array(), $this->dataManager->listFlows());
+	}
+
+	public function testListInstances() {
+		// create three flows
+		$createLocationFlow1 = $this->getFlow($this->createLocationFlowName, $this->createLocationFlowInstanceId);
+		$createLocationFlow2 = $this->getFlow($this->createLocationFlowName, 'other-instance');
+		$createVehicleFlow = $this->getFlow($this->createVehicleFlowName, $this->createVehicleFlowInstanceId);
+
+		// save their data
+		$this->dataManager->save($createLocationFlow1, $this->createLocationFlowData);
+		$this->dataManager->save($createLocationFlow2, $this->createLocationFlowData);
+		$this->dataManager->save($createVehicleFlow, $this->createVehicleFlowData);
+
+		// get instances of one flow
+		$expectedResult = array(
+			$this->createLocationFlowInstanceId,
+			'other-instance',
+		);
+		$this->assertEquals($expectedResult, $this->dataManager->listInstances($this->createLocationFlowName));
+	}
+
+	/**
+	 * Ensure that even without any data an array is returned.
+	 */
+	public function testListInstances_emptyStorage() {
+		$this->assertEquals(array(), $this->dataManager->listInstances('whatever'));
+	}
+
+	public function testDropAll() {
+		// create a flow
+		$createLocationFlow = $this->getFlow($this->createLocationFlowName, $this->createLocationFlowInstanceId);
+
+		// save its data
+		$this->dataManager->save($createLocationFlow, $this->createLocationFlowData);
+
+		// drop all data
+		$this->dataManager->dropAll();
+
+		// ensure all data has been dropped
+		$this->assertFalse($this->storage->has(DataManagerInterface::STORAGE_ROOT));
+	}
+
+	/**
+	 * @param string $name
+	 * @param string $instanceId
+	 * return PHPUnit_Framework_MockObject_MockObject|FormFlow
+	 */
+	protected function getFlow($name, $instanceId) {
+		$flow = $this->getFlowWithMockedMethods(array('getName'));
+
+		$flow
+			->expects($this->any())
+			->method('getName')
+			->will($this->returnValue($name))
+		;
+
+		$flow->setInstanceId($instanceId);
+
+		return $flow;
+	}
+
+}

--- a/Tests/UnitTestCase.php
+++ b/Tests/UnitTestCase.php
@@ -5,7 +5,7 @@ namespace Craue\FormFlowBundle\Tests;
 use Craue\FormFlowBundle\Form\FormFlow;
 use Craue\FormFlowBundle\Form\FormFlowInterface;
 use Craue\FormFlowBundle\Form\StepInterface;
-use Craue\FormFlowBundle\Storage\StorageInterface;
+use Craue\FormFlowBundle\Storage\DataManagerInterface;
 
 /**
  * @author Christian Raue <christian.raue@gmail.com>
@@ -44,10 +44,10 @@ abstract class UnitTestCase extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @return \PHPUnit_Framework_MockObject_MockObject|StorageInterface
+	 * @return \PHPUnit_Framework_MockObject_MockObject|DataManagerInterface
 	 */
-	protected function getMockedStorageInterface() {
-		return $this->getMock('\Craue\FormFlowBundle\Storage\StorageInterface');
+	protected function getMockedDataManagerInterface() {
+		return $this->getMock('\Craue\FormFlowBundle\Storage\DataManagerInterface');
 	}
 
 }

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -104,6 +104,11 @@ This version adds support for concurrent instances of the same flow, which requi
 
 ## Flow
 
+- Some methods have been removed.
+
+	- `setStepDataKey`/`getStepDataKey`
+	- `setStorage`/`getStorage` (use `setDataManager`/`getDataManager` instead)
+
 - Some methods have been renamed.
 
 	- `setDynamicStepNavigationParameter` to `setDynamicStepNavigationStepParameter`


### PR DESCRIPTION
This changes the structure of saved step data to allow managing it for further features, like #116.
With the old way, it was not easily possible to analyze the stored data from outside a flow. Now, by adding some metadata, it's possible to scan for flows and their instances, or to drop data of all flows.

I'm not perfectly satisfied with the name `DataManager`, so I'm open to suggestions.

BC break: The new structure is incompatible to the old one, thus currently running flows will appear being reset. At first I planned to add a migration mechanism, but because a custom `$stepDataKey` could have been set for each flow, I dropped that idea.