### PR TITLE
FormFlow::saveCurrentStepData() fails for embedded forms with file uploads

### DIFF
--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -663,7 +663,7 @@ abstract class FormFlow implements FormFlowInterface {
 		$currentStepData = $request->request->get($formName, array());
 
 		if ($this->handleFileUploads) {
-			$currentStepData = array_merge($currentStepData, $request->files->get($formName, array()));
+			$currentStepData = array_merge_recursive($currentStepData, $request->files->get($formName, array()));
 		}
 
 		$stepData[$this->currentStepNumber] = $currentStepData;


### PR DESCRIPTION
This fixes a bug where "file" fields in an embedded subform replaced all other fields in the same flow step. `array_merge()` simply replaces the data of the embedded form with the file fields of the embedded form. We have to merge recursively to add the file fields in embedded forms.

This is just a quick fix for the problem, we probably need to adjust the test suite to cover this case. The quickest way is probably to modify the test for #64 by adding a file field.
