### PR TITLE
Update composer version in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ A live demo showcasing these features is available at http://craue.de/sf2playgro
 
 ## Get the bundle
 
-Let Composer download and install the bundle by running in a shell.
+Let Composer download and install the bundle by running
 
 ```sh
-php composer.phar require craue/formflow-bundle:dev-master
+php composer.phar require craue/formflow-bundle:*
 ```
+
+in a shell.
 
 ## Enable the bundle
 
@@ -308,7 +310,7 @@ So place this in your base template:
 {% endstylesheets %}
 ```
 
-You can easily customize the default button look by using these variables to add one or more CSS classes to them:
+You can easily customize the default button look by using these variables to add one or more CSS classes to them (option not available in the stable version):
 
 - `craue_formflow_button_class_last` will apply either to the __next__ or __finish__ button
 - `craue_formflow_button_class_finish` will specifically apply to the __finish__ button

--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ A live demo showcasing these features is available at http://craue.de/sf2playgro
 
 ## Get the bundle
 
-Let Composer download and install the bundle by running
+Let Composer download and install the bundle by running in a shell.
 
 ```sh
-php composer.phar require craue/formflow-bundle:~2.0
+php composer.phar require craue/formflow-bundle:dev-master
 ```
-
-in a shell.
 
 ## Enable the bundle
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ So place this in your base template:
 {% endstylesheets %}
 ```
 
-You can easily customize the default button look by using these variables to add one or more CSS classes to them (option not available in the stable version):
+You can easily customize the default button look by using these variables to add one or more CSS classes to them (option not available in all versions):
 
 - `craue_formflow_button_class_last` will apply either to the __next__ or __finish__ button
 - `craue_formflow_button_class_finish` will specifically apply to the __finish__ button


### PR DESCRIPTION
Update composer version in the documentation because some options in the doc need to be with the development version (exemple: customize the default button look).