### PR TITLE
form options for each step while preserving the generated step-based validation group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#133]+[#134]: added Farsi translation
 - [#142]: added support for the "redirect after submit" pattern
 - [#146]: handling of file uploads
+- [#175]+[#178]: form options for each step
 
 [#98]: https://github.com/craue/CraueFormFlowBundle/issues/98
 [#101]: https://github.com/craue/CraueFormFlowBundle/issues/101
@@ -36,6 +37,8 @@
 [#145]: https://github.com/craue/CraueFormFlowBundle/issues/145
 [#146]: https://github.com/craue/CraueFormFlowBundle/issues/146
 [#148]: https://github.com/craue/CraueFormFlowBundle/issues/148
+[#175]: https://github.com/craue/CraueFormFlowBundle/issues/175
+[#178]: https://github.com/craue/CraueFormFlowBundle/issues/178
 
 ## 2.1.7 (2015-03-06)
 

--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -686,7 +686,7 @@ abstract class FormFlow implements FormFlowInterface {
 
 		$options = array();
 		if (!$this->revalidatePreviousSteps) {
-			$options['validation_groups'] = array(); // disable validation
+			$options['validation_groups'] = false; // disable validation
 		}
 
 		foreach ($this->getSteps() as $step) {
@@ -716,15 +716,20 @@ abstract class FormFlow implements FormFlowInterface {
 	}
 
 	public function getFormOptions($step, array $options = array()) {
+		// override options in a specific order
 		$options = array_merge(
 			$this->getGenericFormOptions(),
 			$this->getStep($step)->getFormOptions(),
 			$options
 		);
 
+		// always add the generated step-based validation group (unless it's set to false explicitly)
 		if (!array_key_exists('validation_groups', $options)) {
-			$options['validation_groups'] = array(
-				$this->getValidationGroupPrefix() . $step,
+			$options['validation_groups'] = array($this->getValidationGroupPrefix() . $step);
+		} elseif ($options['validation_groups'] !== false) {
+			$options['validation_groups'] = array_merge(
+				array($this->getValidationGroupPrefix() . $step),
+				(array) $options['validation_groups']
 			);
 		}
 

--- a/Form/Step.php
+++ b/Form/Step.php
@@ -55,11 +55,11 @@ class Step implements StepInterface {
 				case 'type':
 					$step->setType($value);
 					break;
-				case 'skip':
-					$step->setSkip($value);
-					break;
 				case 'form_options':
 					$step->setFormOptions($value);
+					break;
+				case 'skip':
+					$step->setSkip($value);
 					break;
 				default:
 					throw new \InvalidArgumentException(sprintf('Invalid step config option "%s" given.', $key));
@@ -67,26 +67,6 @@ class Step implements StepInterface {
 		}
 
 		return $step;
-	}
-
-	/**
-	 * @param array $formOptions
-	 */
-	public function setFormOptions($formOptions) {
-		if (is_array($formOptions)) {
-			$this->formOptions = $formOptions;
-
-			return;
-		}
-
-		throw new InvalidTypeException($formOptions, 'array');
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function getFormOptions() {
-		return $this->formOptions;
 	}
 
 	/**
@@ -151,6 +131,26 @@ class Step implements StepInterface {
 	}
 
 	/**
+	 * @param array $formOptions
+	 */
+	public function setFormOptions($formOptions) {
+		if (is_array($formOptions)) {
+			$this->formOptions = $formOptions;
+
+			return;
+		}
+
+		throw new InvalidTypeException($formOptions, 'array');
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getFormOptions() {
+		return $this->formOptions;
+	}
+
+	/**
 	 * @param boolean|callable $skip
 	 * @throws InvalidTypeException
 	 */
@@ -194,4 +194,5 @@ class Step implements StepInterface {
 	public function isSkipped() {
 		return $this->skipped === true;
 	}
+
 }

--- a/Form/StepInterface.php
+++ b/Form/StepInterface.php
@@ -27,14 +27,14 @@ interface StepInterface {
 	function getType();
 
 	/**
-	 * @return boolean
-	 */
-	function isSkipped();
-
-	/**
 	 * @return array
 	 */
 	function getFormOptions();
+
+	/**
+	 * @return boolean
+	 */
+	function isSkipped();
 
 	/**
 	 * @param integer $estimatedCurrentStepNumber

--- a/README.md
+++ b/README.md
@@ -394,6 +394,8 @@ Valid options per step are:
 - `type` (`FormTypeInterface`|`string`|`null`)
 	- The form type used to build the form for that step.
 	- If using a string, it has to be the registered alias of the form type.
+- `form_options` (`array`)
+	- Options passed to the form type of that step.
 - `skip` (`callable`|`boolean`)
 	- Decides whether the step will be skipped.
 	- If using a callable...
@@ -429,6 +431,9 @@ protected function loadStepsConfig() {
 		2 => array(
 			'label' => 'engine',
 			'type' => 'createVehicleStep2',
+			'form_options' => array(
+				'validation_groups' => array('Default'),
+			),
 			'skip' => function($estimatedCurrentStepNumber, FormFlowInterface $flow) {
 				return $estimatedCurrentStepNumber > 1 && !$flow->getFormData()->canHaveEngine();
 			},
@@ -482,23 +487,25 @@ public function createVehicleAction() {
 
 ## Passing step-based options to the form type
 
-To set options based on previous steps (e.g. to render fields depending on submitted data) you can override method
-`getFormOptions` of your flow class.
-Before you can use the options you have to define them in your form type class:
+To pass individual options to each step's form type you can use the step config option `form_options`:
 
 ```php
-// in src/MyCompany/MyBundle/Form/CreateVehicleStep2Form.php
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
-public function setDefaultOptions(OptionsResolverInterface $resolver) {
-	$resolver->setDefaults(array(
-		// ...
-		'numberOfWheels' => null,
-	));
+// in src/MyCompany/MyBundle/Form/CreateVehicleFlow.php
+protected function loadStepsConfig() {
+	return array(
+		array(
+			'label' => 'wheels',
+			'type' => 'createVehicleStep1',
+			'form_options' => array(
+				'validation_groups' => array('Default'),
+			),
+		),
+	);
 }
 ```
 
-Then you can set them in your flow class.
+Alternatively, to set options based on previous steps (e.g. to render fields depending on submitted data) you can override method
+`getFormOptions` of your flow class:
 
 ```php
 // in src/MyCompany/MyBundle/Form/CreateVehicleFlow.php

--- a/Tests/Form/StepTest.php
+++ b/Tests/Form/StepTest.php
@@ -178,6 +178,43 @@ class StepTest extends UnitTestCase {
 	}
 
 	/**
+	 * @dataProvider dataSetGetFormOptions
+	 */
+	public function testSetGetFormOptions($formOptions) {
+		$step = new Step();
+		$step->setFormOptions($formOptions);
+		$this->assertEquals($formOptions, $step->getFormOptions());
+	}
+
+	public function dataSetGetFormOptions() {
+		return array(
+			array(array()),
+			array(array(
+				'validation_groups' => array('Default'),
+			)),
+		);
+	}
+
+	/**
+	 * @dataProvider dataSetGetFormOptions_invalidArguments
+	 * @expectedException \Craue\FormFlowBundle\Exception\InvalidTypeException
+	 */
+	public function testSetGetFormOptions_invalidArguments($formOptions) {
+		$step = new Step();
+		$step->setFormOptions($formOptions);
+	}
+
+	public function dataSetGetFormOptions_invalidArguments() {
+		return array(
+			array(null),
+			array(true),
+			array(false),
+			array(123),
+			array(new \stdClass()),
+		);
+	}
+
+	/**
 	 * @dataProvider dataSetSkip_invalidArguments
 	 * @expectedException \Craue\FormFlowBundle\Exception\InvalidTypeException
 	 */


### PR DESCRIPTION
This PR
 - merges #175 with the addition to preserve the generated step-based validation group,
 - replaces and closes #172 as I thinks it's not necessary anymore,
 - closes #170.

@fullpipe, @AdamBoxall: Ok?