### PR TITLE
rename step config option `type` to `form_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - [#104]: removed options from method `createForm`
   - [#145]: bumped Symfony dependency to 2.3
   - [#148]: restructured data storage
+  - [#180]: renamed step config option `type` to `form_type`
   - removed the step field template
   - renamed property `step` to `stepNumber` and method `getStep` to `getStepNumber` within event classes
 - [#98]+[#143]: add a validation error to the current form if a form of a previous step became invalid
@@ -39,6 +40,7 @@
 [#148]: https://github.com/craue/CraueFormFlowBundle/issues/148
 [#175]: https://github.com/craue/CraueFormFlowBundle/issues/175
 [#178]: https://github.com/craue/CraueFormFlowBundle/issues/178
+[#180]: https://github.com/craue/CraueFormFlowBundle/issues/180
 
 ## 2.1.7 (2015-03-06)
 

--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -891,7 +891,7 @@ abstract class FormFlow implements FormFlowInterface {
 	 * @return FormInterface
 	 */
 	protected function createFormForStep($stepNumber, array $options = array()) {
-		$formType = $this->getStep($stepNumber)->getType();
+		$formType = $this->getStep($stepNumber)->getFormType();
 		$options = $this->getFormOptions($stepNumber, $options);
 
 		return $this->formFactory->create($formType !== null ? $formType : 'form', $this->formData, $options);

--- a/Form/Step.php
+++ b/Form/Step.php
@@ -25,7 +25,7 @@ class Step implements StepInterface {
 	/**
 	 * @var FormTypeInterface|string|null
 	 */
-	protected $type = null;
+	protected $formType = null;
 
 	/**
 	 * @var array
@@ -52,8 +52,8 @@ class Step implements StepInterface {
 				case 'label':
 					$step->setLabel($value);
 					break;
-				case 'type':
-					$step->setType($value);
+				case 'form_type':
+					$step->setFormType($value);
 					break;
 				case 'form_options':
 					$step->setFormOptions($value);
@@ -113,21 +113,21 @@ class Step implements StepInterface {
 	 * @param FormTypeInterface|string|null $type
 	 * @throws InvalidTypeException
 	 */
-	public function setType($type) {
-		if ($type === null || is_string($type) || $type instanceof FormTypeInterface) {
-			$this->type = $type;
+	public function setFormType($formType) {
+		if ($formType === null || is_string($formType) || $formType instanceof FormTypeInterface) {
+			$this->formType = $formType;
 
 			return;
 		}
 
-		throw new InvalidTypeException($type, array('null', 'string', 'Symfony\Component\Form\FormTypeInterface'));
+		throw new InvalidTypeException($formType, array('null', 'string', 'Symfony\Component\Form\FormTypeInterface'));
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getType() {
-		return $this->type;
+	public function getFormType() {
+		return $this->formType;
 	}
 
 	/**

--- a/Form/Step.php
+++ b/Form/Step.php
@@ -52,6 +52,8 @@ class Step implements StepInterface {
 				case 'label':
 					$step->setLabel($value);
 					break;
+				case 'type':
+					trigger_error('Step config option "type" is deprecated since version 3.0. Use "form_type" instead.', E_USER_DEPRECATED);
 				case 'form_type':
 					$step->setFormType($value);
 					break;

--- a/Form/StepInterface.php
+++ b/Form/StepInterface.php
@@ -24,7 +24,7 @@ interface StepInterface {
 	/**
 	 * @return FormTypeInterface|string|null
 	 */
-	function getType();
+	function getFormType();
 
 	/**
 	 * @return array

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ class CreateVehicleFlow extends FormFlow {
 		return array(
 			array(
 				'label' => 'wheels',
-				'type' => $this->formType,
+				'form_type' => $this->formType,
 			),
 			array(
 				'label' => 'engine',
-				'type' => $this->formType,
+				'form_type' => $this->formType,
 				'skip' => function($estimatedCurrentStepNumber, FormFlowInterface $flow) {
 					return $estimatedCurrentStepNumber > 1 && !$flow->getFormData()->canHaveEngine();
 				},
@@ -189,11 +189,11 @@ class CreateVehicleFlow extends FormFlow {
 		return array(
 			array(
 				'label' => 'wheels',
-				'type' => new CreateVehicleStep1Form(),
+				'form_type' => new CreateVehicleStep1Form(),
 			),
 			array(
 				'label' => 'engine',
-				'type' => new CreateVehicleStep2Form(),
+				'form_type' => new CreateVehicleStep2Form(),
 				'skip' => function($estimatedCurrentStepNumber, FormFlowInterface $flow) {
 					return $estimatedCurrentStepNumber > 1 && !$flow->getFormData()->canHaveEngine();
 				},
@@ -391,7 +391,7 @@ Valid options per step are:
 - `label` (`string`|`null`)
 	- If you'd like to render an overview of all steps you have to set the `label` option for each step.
 	- By default, the labels will be translated using the `messages` domain when rendered in Twig.
-- `type` (`FormTypeInterface`|`string`|`null`)
+- `form_type` (`FormTypeInterface`|`string`|`null`)
 	- The form type used to build the form for that step.
 	- If using a string, it has to be the registered alias of the form type.
 - `form_options` (`array`)
@@ -409,10 +409,10 @@ Valid options per step are:
 protected function loadStepsConfig() {
 	return array(
 		array(
-			'type' => new CreateVehicleStep1Form(),
+			'form_type' => new CreateVehicleStep1Form(),
 		),
 		array(
-			'type' => new CreateVehicleStep2Form(),
+			'form_type' => new CreateVehicleStep2Form(),
 			'skip' => true,
 		),
 		array(
@@ -426,11 +426,11 @@ protected function loadStepsConfig() {
 	return array(
 		1 => array(
 			'label' => 'wheels',
-			'type' => new CreateVehicleStep1Form(),
+			'form_type' => new CreateVehicleStep1Form(),
 		),
 		2 => array(
 			'label' => 'engine',
-			'type' => 'createVehicleStep2',
+			'form_type' => 'createVehicleStep2',
 			'form_options' => array(
 				'validation_groups' => array('Default'),
 			),
@@ -495,7 +495,7 @@ protected function loadStepsConfig() {
 	return array(
 		array(
 			'label' => 'wheels',
-			'type' => 'createVehicleStep1',
+			'form_type' => 'createVehicleStep1',
 			'form_options' => array(
 				'validation_groups' => array('Default'),
 			),

--- a/Tests/Form/StepBcTest.php
+++ b/Tests/Form/StepBcTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Craue\FormFlowBundle\Tests\Form;
+
+use Craue\FormFlowBundle\Form\Step;
+use Craue\FormFlowBundle\Tests\UnitTestCase;
+
+/**
+ * Tests for BC.
+ *
+ * @group unit
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2015 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class StepBcTest extends UnitTestCase {
+
+	/**
+	 * @var string[]
+	 */
+	private $deprecationNotices;
+
+	protected function setUp() {
+		$this->deprecationNotices = array();
+
+		$that = $this;
+		set_error_handler(function($errno, $errstr, $errfile, $errline) use ($that) {
+			if ($errno === E_USER_DEPRECATED) {
+				$that->addDepreactionNotice($errstr);
+			}
+		});
+	}
+
+	protected function tearDown() {
+		restore_error_handler();
+	}
+
+	public function addDepreactionNotice($notice) {
+		$this->deprecationNotices[] = $notice;
+	}
+
+	public function testCreateFromConfig_bcOptionType() {
+		$step = Step::createFromConfig(1, array(
+			'type' => 'myFormType',
+		));
+
+		$this->assertEquals(array('Step config option "type" is deprecated since version 3.0. Use "form_type" instead.'), $this->deprecationNotices);
+		$this->assertEquals('myFormType', $step->getFormType());
+	}
+
+}

--- a/Tests/Form/StepTest.php
+++ b/Tests/Form/StepTest.php
@@ -21,7 +21,7 @@ class StepTest extends UnitTestCase {
 		$step = Step::createFromConfig(1, array());
 		$this->assertSame(1, $step->getNumber());
 		$this->assertNull($step->getLabel());
-		$this->assertNull($step->getType());
+		$this->assertNull($step->getFormType());
 		$this->assertFalse($step->isSkipped());
 		$this->assertEquals(array(), $step->getFormOptions());
 		$step->evaluateSkipping(1, $flow);
@@ -145,15 +145,15 @@ class StepTest extends UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetGetType
+	 * @dataProvider dataSetGetFormType
 	 */
-	public function testSetGetType($type) {
+	public function testSetGetFormType($formType) {
 		$step = new Step();
-		$step->setType($type);
-		$this->assertEquals($type, $step->getType());
+		$step->setFormType($formType);
+		$this->assertEquals($formType, $step->getFormType());
 	}
 
-	public function dataSetGetType() {
+	public function dataSetGetFormType() {
 		return array(
 			array(null),
 			array('myFormType'),
@@ -162,15 +162,15 @@ class StepTest extends UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetGetType_invalidArguments
+	 * @dataProvider dataSetGetFormType_invalidArguments
 	 * @expectedException \Craue\FormFlowBundle\Exception\InvalidTypeException
 	 */
-	public function testSetGetType_invalidArguments($type) {
+	public function testSetGetFormType_invalidArguments($formType) {
 		$step = new Step();
-		$step->setType($type);
+		$step->setFormType($formType);
 	}
 
-	public function dataSetGetType_invalidArguments() {
+	public function dataSetGetFormType_invalidArguments() {
 		return array(
 			array(123),
 			array($this->getMock('Symfony\Component\Form\Test\FormInterface')),

--- a/Tests/IntegrationTestBundle/Form/CreateTopicFlow.php
+++ b/Tests/IntegrationTestBundle/Form/CreateTopicFlow.php
@@ -41,15 +41,15 @@ class CreateTopicFlow extends FormFlow {
 		return array(
 			array(
 				'label' => 'basics',
-				'type' => $this->formType,
+				'form_type' => $this->formType,
 			),
 			array(
 				'label' => 'comment',
-				'type' => $this->formType,
+				'form_type' => $this->formType,
 			),
 			array(
 				'label' => 'bug_details',
-				'type' => $this->formType,
+				'form_type' => $this->formType,
 				'skip' => function($estimatedCurrentStepNumber, FormFlowInterface $flow) {
 					return $estimatedCurrentStepNumber > 1 && !$flow->getFormData()->isBugReport();
 				},

--- a/Tests/IntegrationTestBundle/Form/CreateVehicleFlow.php
+++ b/Tests/IntegrationTestBundle/Form/CreateVehicleFlow.php
@@ -26,11 +26,11 @@ class CreateVehicleFlow extends FormFlow {
 		return array(
 			array(
 				'label' => 'wheels',
-				'type' => 'createVehicle',
+				'form_type' => 'createVehicle',
 			),
 			array(
 				'label' => 'engine',
-				'type' => 'createVehicle',
+				'form_type' => 'createVehicle',
 				'skip' => function($estimatedCurrentStepNumber, FormFlowInterface $flow) {
 					return $estimatedCurrentStepNumber > 1 && !$flow->getFormData()->canHaveEngine();
 				},

--- a/Tests/IntegrationTestBundle/Form/Issue149Flow.php
+++ b/Tests/IntegrationTestBundle/Form/Issue149Flow.php
@@ -25,15 +25,15 @@ class Issue149Flow extends FormFlow {
 		return array(
 			array(
 				'label' => 'step1',
-				'type' => 'issue149',
+				'form_type' => 'issue149',
 			),
 			array(
 				'label' => 'step2',
-				'type' => 'issue149',
+				'form_type' => 'issue149',
 			),
 			array(
 				'label' => 'step3',
-				'type' => 'issue149',
+				'form_type' => 'issue149',
 			),
 		);
 	}

--- a/Tests/IntegrationTestBundle/Form/Issue64Flow.php
+++ b/Tests/IntegrationTestBundle/Form/Issue64Flow.php
@@ -25,19 +25,19 @@ class Issue64Flow extends FormFlow {
 		return array(
 			array(
 				'label' => 'step1',
-				'type' => 'issue64',
+				'form_type' => 'issue64',
 			),
 			array(
 				'label' => 'step2',
-				'type' => 'issue64',
+				'form_type' => 'issue64',
 			),
 			array(
 				'label' => 'step3',
-				'type' => 'issue64',
+				'form_type' => 'issue64',
 			),
 			array(
 				'label' => 'step4',
-				'type' => 'issue64',
+				'form_type' => 'issue64',
 			),
 		);
 	}

--- a/Tests/IntegrationTestBundle/Form/PhotoUploadFlow.php
+++ b/Tests/IntegrationTestBundle/Form/PhotoUploadFlow.php
@@ -25,15 +25,15 @@ class PhotoUploadFlow extends FormFlow {
 		return array(
 			array(
 				'label' => 'select a photo',
-				'type' => new PhotoUploadForm(),
+				'form_type' => new PhotoUploadForm(),
 			),
 			array(
 				'label' => 'describe the photo',
-				'type' => new PhotoUploadForm(),
+				'form_type' => new PhotoUploadForm(),
 			),
 			array(
 				'label' => 'confirmation',
-				'type' => new PhotoUploadForm(),
+				'form_type' => new PhotoUploadForm(),
 			),
 		);
 	}

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1,5 +1,34 @@
 # Upgrade from 2.1.x to 3.0
 
+## Renaming step config option `type` to `form_type`
+
+The step config option to specify the form type for each step within the `loadStepsConfig` method has been renamed from
+`type` to `form_type`. This was done for the sake of consistency with the newly added option `form_options`.
+
+	before:
+	```php
+	protected function loadStepsConfig() {
+		return array(
+			array(
+				'form' => $this->formType,
+			),
+			// ...
+		);
+	}
+	```
+
+	after:
+	```php
+	protected function loadStepsConfig() {
+		return array(
+			array(
+				'form_type' => $this->formType,
+			),
+			// ...
+		);
+	}
+	```
+
 ## Concurrent instances of the same flow
 
 This version adds support for concurrent instances of the same flow, which required a change in the handling of flows.
@@ -117,6 +146,17 @@ This version adds support for concurrent instances of the same flow, which requi
 - A property has been renamed.
 
 	- `dynamicStepNavigationParameter` to `dynamicStepNavigationStepParameter`
+
+## Step
+
+- Some methods have been renamed.
+
+	- `setType` to `setFormType`
+	- `getType` to `getFormType`
+
+- A property has been renamed.
+
+	- `type` to `formType`
 
 ## Template
 


### PR DESCRIPTION
#178 introduced `form_options`, so `type` should be renamed to `form_type` for the sake of consistency.