### PR TITLE
reduce deprecation notices

### DIFF
--- a/Form/Extension/FormFlowFormExtension.php
+++ b/Form/Extension/FormFlowFormExtension.php
@@ -18,7 +18,9 @@ class FormFlowFormExtension extends AbstractTypeExtension {
 	 * {@inheritDoc}
 	 */
 	public function getExtendedType() {
-		return 'form';
+		$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+
+		return $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
 	}
 
 	/**
@@ -50,7 +52,8 @@ class FormFlowFormExtension extends AbstractTypeExtension {
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options) {
 		if (array_key_exists('flow_step', $options) && array_key_exists('flow_step_key', $options)) {
-			$builder->add($options['flow_step_key'], 'hidden', array(
+			$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+			$builder->add($options['flow_step_key'], $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType' : 'hidden', array(
 				'data' => $options['flow_step'],
 				'mapped' => false,
 				'flow_step_key' => $options['flow_step_key'],

--- a/Form/Extension/FormFlowStepFieldExtension.php
+++ b/Form/Extension/FormFlowStepFieldExtension.php
@@ -19,7 +19,9 @@ class FormFlowStepFieldExtension extends AbstractTypeExtension {
 	 * {@inheritDoc}
 	 */
 	public function getExtendedType() {
-		return 'hidden';
+		$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+
+		return $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType' : 'hidden';
 	}
 
 	/**

--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -685,7 +685,12 @@ abstract class FormFlow implements FormFlowInterface {
 		$formType = $this->getStep($stepNumber)->getType();
 		$options = $this->getFormOptions($stepNumber, $options);
 
-		return $this->formFactory->create($formType !== null ? $formType : 'form', $this->formData, $options);
+		if ($formType === null) {
+			$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+			$formType = $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
+		}
+
+		return $this->formFactory->create($formType, $this->formData, $options);
 	}
 
 	/**

--- a/Resources/config/form_flow.xml
+++ b/Resources/config/form_flow.xml
@@ -37,11 +37,11 @@
 		</service>
 
 		<service id="craue.form.flow.form_extension" class="Craue\FormFlowBundle\Form\Extension\FormFlowFormExtension">
-			<tag name="form.type_extension" alias="form" />
+			<tag name="form.type_extension" alias="form" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
 		</service>
 
 		<service id="craue.form.flow.step_field_extension" class="Craue\FormFlowBundle\Form\Extension\FormFlowStepFieldExtension">
-			<tag name="form.type_extension" alias="hidden" />
+			<tag name="form.type_extension" alias="hidden" extended-type="Symfony\Component\Form\Extension\Core\Type\HiddenType" />
 		</service>
 	</services>
 

--- a/Tests/IntegrationTestBundle/Form/CreateTopicFlow.php
+++ b/Tests/IntegrationTestBundle/Form/CreateTopicFlow.php
@@ -4,7 +4,6 @@ namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form;
 
 use Craue\FormFlowBundle\Form\FormFlow;
 use Craue\FormFlowBundle\Form\FormFlowInterface;
-use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * @author Christian Raue <christian.raue@gmail.com>
@@ -14,18 +13,6 @@ use Symfony\Component\Form\FormTypeInterface;
 class CreateTopicFlow extends FormFlow {
 
 	protected $allowDynamicStepNavigation = true;
-
-	/**
-	 * @var FormTypeInterface
-	 */
-	protected $formType;
-
-	/**
-	 * @param FormTypeInterface $formType
-	 */
-	public function setFormType(FormTypeInterface $formType) {
-		$this->formType = $formType;
-	}
 
 	/**
 	 * {@inheritDoc}
@@ -38,18 +25,21 @@ class CreateTopicFlow extends FormFlow {
 	 * {@inheritDoc}
 	 */
 	protected function loadStepsConfig() {
+		$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+		$formType = $useFqcn ? 'Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form\CreateTopicForm' : 'createTopic';
+
 		return array(
 			array(
 				'label' => 'basics',
-				'type' => $this->formType,
+				'type' => $formType,
 			),
 			array(
 				'label' => 'comment',
-				'type' => $this->formType,
+				'type' => $formType,
 			),
 			array(
 				'label' => 'bug_details',
-				'type' => $this->formType,
+				'type' => $formType,
 				'skip' => function($estimatedCurrentStepNumber, FormFlowInterface $flow) {
 					return $estimatedCurrentStepNumber > 1 && !$flow->getFormData()->isBugReport();
 				},

--- a/Tests/IntegrationTestBundle/Form/CreateTopicForm.php
+++ b/Tests/IntegrationTestBundle/Form/CreateTopicForm.php
@@ -19,6 +19,7 @@ class CreateTopicForm extends AbstractType {
 	 * {@inheritDoc}
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options) {
+		$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix'); // Symfony's Form component >=2.8
 		$isBugReport = $options['isBugReport'];
 
 		switch ($options['flow_step']) {
@@ -28,19 +29,19 @@ class CreateTopicForm extends AbstractType {
 					'required' => false,
 				));
 				$choices = Topic::getValidCategories();
-				$builder->add('category', 'choice', array(
+				$builder->add('category', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array(
 					'choices' => array_combine($choices, $choices),
 					'empty_value' => '',
 				));
 				break;
 			case 2:
-				$builder->add('comment', 'textarea', array(
+				$builder->add('comment', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\TextareaType' : 'textarea', array(
 					'required' => false,
 				));
 				break;
 			case 3:
 				if ($isBugReport) {
-					$builder->add('details', 'textarea');
+					$builder->add('details', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\TextareaType' : 'textarea');
 				}
 				break;
 		}
@@ -67,6 +68,13 @@ class CreateTopicForm extends AbstractType {
 	 * {@inheritDoc}
 	 */
 	public function getName() {
+		return $this->getBlockPrefix();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getBlockPrefix() {
 		return 'createTopic';
 	}
 

--- a/Tests/IntegrationTestBundle/Form/CreateTopicForm.php
+++ b/Tests/IntegrationTestBundle/Form/CreateTopicForm.php
@@ -20,6 +20,7 @@ class CreateTopicForm extends AbstractType {
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options) {
 		$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix'); // Symfony's Form component >=2.8
+		$usePlaceholder = method_exists('Symfony\Component\Form\AbstractType', 'configureOptions'); // Symfony's Form component 2.6 deprecated the "empty_value" option, but there seems to be no way to detect that version, so stick to this >=2.7 check.
 		$isBugReport = $options['isBugReport'];
 
 		switch ($options['flow_step']) {
@@ -31,7 +32,7 @@ class CreateTopicForm extends AbstractType {
 				$choices = Topic::getValidCategories();
 				$builder->add('category', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array(
 					'choices' => array_combine($choices, $choices),
-					'empty_value' => '',
+					$usePlaceholder ? 'placeholder' : 'empty_value' => '',
 				));
 				break;
 			case 2:

--- a/Tests/IntegrationTestBundle/Form/CreateTopicForm.php
+++ b/Tests/IntegrationTestBundle/Form/CreateTopicForm.php
@@ -29,11 +29,15 @@ class CreateTopicForm extends AbstractType {
 				$builder->add('description', null, array(
 					'required' => false,
 				));
+				$defaultChoiceOptions = array();
+				if ($useFqcn) {
+					$defaultChoiceOptions['choices_as_values'] = true;
+				}
 				$choices = Topic::getValidCategories();
-				$builder->add('category', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array(
+				$builder->add('category', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array_merge($defaultChoiceOptions, array(
 					'choices' => array_combine($choices, $choices),
 					$usePlaceholder ? 'placeholder' : 'empty_value' => '',
-				));
+				)));
 				break;
 			case 2:
 				$builder->add('comment', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\TextareaType' : 'textarea', array(

--- a/Tests/IntegrationTestBundle/Form/CreateVehicleFlow.php
+++ b/Tests/IntegrationTestBundle/Form/CreateVehicleFlow.php
@@ -23,14 +23,17 @@ class CreateVehicleFlow extends FormFlow {
 	 * {@inheritDoc}
 	 */
 	protected function loadStepsConfig() {
+		$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+		$formType = $useFqcn ? 'Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form\CreateVehicleForm' : 'createVehicle';
+
 		return array(
 			array(
 				'label' => 'wheels',
-				'type' => 'createVehicle',
+				'type' => $formType,
 			),
 			array(
 				'label' => 'engine',
-				'type' => 'createVehicle',
+				'type' => $formType,
 				'skip' => function($estimatedCurrentStepNumber, FormFlowInterface $flow) {
 					return $estimatedCurrentStepNumber > 1 && !$flow->getFormData()->canHaveEngine();
 				},

--- a/Tests/IntegrationTestBundle/Form/CreateVehicleForm.php
+++ b/Tests/IntegrationTestBundle/Form/CreateVehicleForm.php
@@ -19,13 +19,18 @@ class CreateVehicleForm extends AbstractType {
 		$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix'); // Symfony's Form component >=2.8
 		$usePlaceholder = method_exists('Symfony\Component\Form\AbstractType', 'configureOptions'); // Symfony's Form component 2.6 deprecated the "empty_value" option, but there seems to be no way to detect that version, so stick to this >=2.7 check.
 
+		$defaultChoiceOptions = array();
+		if ($useFqcn) {
+			$defaultChoiceOptions['choices_as_values'] = true;
+		}
+
 		switch ($options['flow_step']) {
 			case 1:
 				$choices = array(2, 4);
-				$builder->add('numberOfWheels', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array(
+				$builder->add('numberOfWheels', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array_merge($defaultChoiceOptions, array(
 					'choices' => array_combine($choices, $choices),
 					$usePlaceholder ? 'placeholder' : 'empty_value' => '',
-				));
+				)));
 				break;
 			case 2:
 				$choices = array(
@@ -33,10 +38,10 @@ class CreateVehicleForm extends AbstractType {
 					'gas',
 					'naturalGas',
 				);
-				$builder->add('engine', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array(
+				$builder->add('engine', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array_merge($defaultChoiceOptions, array(
 					'choices' => array_combine($choices, $choices),
 					$usePlaceholder ? 'placeholder' : 'empty_value' => '',
-				));
+				)));
 				break;
 		}
 	}

--- a/Tests/IntegrationTestBundle/Form/CreateVehicleForm.php
+++ b/Tests/IntegrationTestBundle/Form/CreateVehicleForm.php
@@ -16,10 +16,12 @@ class CreateVehicleForm extends AbstractType {
 	 * {@inheritDoc}
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options) {
+		$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix'); // Symfony's Form component >=2.8
+
 		switch ($options['flow_step']) {
 			case 1:
 				$choices = array(2, 4);
-				$builder->add('numberOfWheels', 'choice', array(
+				$builder->add('numberOfWheels', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array(
 					'choices' => array_combine($choices, $choices),
 					'empty_value' => '',
 				));
@@ -30,7 +32,7 @@ class CreateVehicleForm extends AbstractType {
 					'gas',
 					'naturalGas',
 				);
-				$builder->add('engine', 'choice', array(
+				$builder->add('engine', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array(
 					'choices' => array_combine($choices, $choices),
 					'empty_value' => '',
 				));
@@ -42,6 +44,13 @@ class CreateVehicleForm extends AbstractType {
 	 * {@inheritDoc}
 	 */
 	public function getName() {
+		return $this->getBlockPrefix();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getBlockPrefix() {
 		return 'createVehicle';
 	}
 

--- a/Tests/IntegrationTestBundle/Form/CreateVehicleForm.php
+++ b/Tests/IntegrationTestBundle/Form/CreateVehicleForm.php
@@ -17,13 +17,14 @@ class CreateVehicleForm extends AbstractType {
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options) {
 		$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix'); // Symfony's Form component >=2.8
+		$usePlaceholder = method_exists('Symfony\Component\Form\AbstractType', 'configureOptions'); // Symfony's Form component 2.6 deprecated the "empty_value" option, but there seems to be no way to detect that version, so stick to this >=2.7 check.
 
 		switch ($options['flow_step']) {
 			case 1:
 				$choices = array(2, 4);
 				$builder->add('numberOfWheels', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array(
 					'choices' => array_combine($choices, $choices),
-					'empty_value' => '',
+					$usePlaceholder ? 'placeholder' : 'empty_value' => '',
 				));
 				break;
 			case 2:
@@ -34,7 +35,7 @@ class CreateVehicleForm extends AbstractType {
 				);
 				$builder->add('engine', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array(
 					'choices' => array_combine($choices, $choices),
-					'empty_value' => '',
+					$usePlaceholder ? 'placeholder' : 'empty_value' => '',
 				));
 				break;
 		}

--- a/Tests/IntegrationTestBundle/Form/Issue64Flow.php
+++ b/Tests/IntegrationTestBundle/Form/Issue64Flow.php
@@ -22,22 +22,25 @@ class Issue64Flow extends FormFlow {
 	 * {@inheritDoc}
 	 */
 	protected function loadStepsConfig() {
+		$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+		$formType = $useFqcn ? 'Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form\Issue64Form' : 'issue64';
+
 		return array(
 			array(
 				'label' => 'step1',
-				'type' => 'issue64',
+				'type' => $formType,
 			),
 			array(
 				'label' => 'step2',
-				'type' => 'issue64',
+				'type' => $formType,
 			),
 			array(
 				'label' => 'step3',
-				'type' => 'issue64',
+				'type' => $formType,
 			),
 			array(
 				'label' => 'step4',
-				'type' => 'issue64',
+				'type' => $formType,
 			),
 		);
 	}

--- a/Tests/IntegrationTestBundle/Form/Issue64Form.php
+++ b/Tests/IntegrationTestBundle/Form/Issue64Form.php
@@ -17,22 +17,24 @@ class Issue64Form extends AbstractType {
 	 * {@inheritDoc}
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options) {
+		$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+
 		switch ($options['flow_step']) {
 			case 1:
-				$subForm = $builder->create('sub', 'form', array(
+				$subForm = $builder->create('sub', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form', array(
 					'data_class' => get_class(new Issue64SubData()),
 				));
-				$subForm->add('prop1', 'text', array(
+				$subForm->add('prop1', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\TextType' : 'text', array(
 					'required' => true,
 				));
 				$builder->add($subForm);
 				break;
 			case 2:
 			case 3:
-				$subForm = $builder->create('sub', 'form', array(
+				$subForm = $builder->create('sub', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form', array(
 					'data_class' => get_class(new Issue64SubData()),
 				));
-				$subForm->add('prop2', 'text', array(
+				$subForm->add('prop2', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\TextType' : 'text', array(
 					'required' => true,
 				));
 				$builder->add($subForm);
@@ -47,6 +49,13 @@ class Issue64Form extends AbstractType {
 	 * {@inheritDoc}
 	 */
 	public function getName() {
+		return $this->getBlockPrefix();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getBlockPrefix() {
 		return 'issue64';
 	}
 

--- a/Tests/IntegrationTestBundle/Resources/config/form_flow.xml
+++ b/Tests/IntegrationTestBundle/Resources/config/form_flow.xml
@@ -13,9 +13,6 @@
 				class="Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form\CreateTopicFlow"
 				parent="craue.form.flow"
 				scope="request">
-			<call method="setFormType">
-				<argument type="service" id="integrationTestBundle.form.createTopic" />
-			</call>
 		</service>
 
 		<service id="integrationTestBundle.form.flow.createVehicle"

--- a/Tests/IntegrationTestBundle/Resources/config/twig.xml
+++ b/Tests/IntegrationTestBundle/Resources/config/twig.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+	Author: Christian Raue <christian.raue@gmail.com>
+	Copyright: 2011-2015 Christian Raue
+	License: http://opensource.org/licenses/mit-license.php MIT License
+-->
+<container xmlns="http://symfony.com/schema/dic/services"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+	<services>
+		<service id="twig.extension.craue_integration_test" class="Craue\FormFlowBundle\Tests\IntegrationTestBundle\Twig\Extension\IntegrationTestTwigExtension" public="false">
+			<tag name="twig.extension" />
+		</service>
+	</services>
+</container>

--- a/Tests/IntegrationTestBundle/Resources/views/form.html.twig
+++ b/Tests/IntegrationTestBundle/Resources/views/form.html.twig
@@ -1,0 +1,5 @@
+{{ form_start(form, {'action': path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params'))}) }}
+	{{ form_errors(form) }}
+	{{ form_rest(form) }}
+	{% include 'CraueFormFlowBundle:FormFlow:buttons.html.twig' %}
+{{ form_end(form) }}

--- a/Tests/IntegrationTestBundle/Resources/views/form_legacy.html.twig
+++ b/Tests/IntegrationTestBundle/Resources/views/form_legacy.html.twig
@@ -1,0 +1,5 @@
+<form method="post" action="{{ path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) }}" {{ form_enctype(form) }}>
+	{{ form_errors(form) }}
+	{{ form_rest(form) }}
+	{% include 'CraueFormFlowBundle:FormFlow:buttons.html.twig' %}
+</form>

--- a/Tests/IntegrationTestBundle/Resources/views/layout_flow.html.twig
+++ b/Tests/IntegrationTestBundle/Resources/views/layout_flow.html.twig
@@ -4,9 +4,5 @@
 <div id="step-number">{{ flow.getCurrentStepNumber() }}</div>
 <div id="form-data">{{ formData | json_encode }}</div>
 <div id="step-list">{% include 'CraueFormFlowBundle:FormFlow:stepList.html.twig' %}</div>
-<form method="post" action="{{ path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) }}" {{ form_enctype(form) }}>
-	{{ form_errors(form) }}
-	{{ form_rest(form) }}
-	{% include 'CraueFormFlowBundle:FormFlow:buttons.html.twig' %}
-</form>
+{% include 'IntegrationTestBundle::' ~ (hasFormStart() ? 'form.html.twig' : 'form_legacy.html.twig') with {'form': form, 'flow': flow} only %}
 {% endblock %}

--- a/Tests/IntegrationTestBundle/Twig/Extension/IntegrationTestTwigExtension.php
+++ b/Tests/IntegrationTestBundle/Twig/Extension/IntegrationTestTwigExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle\Twig\Extension;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2015 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class IntegrationTestTwigExtension extends \Twig_Extension {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getName() {
+		return 'integration_test';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getFunctions() {
+		if (version_compare(\Twig_Environment::VERSION, '1.12', '<')) {
+			return array(
+				'hasFormStart' => new \Twig_Function_Method($this, 'hasFormStart', array('needs_environment' => true)),
+			);
+		}
+
+		return array(
+			new \Twig_SimpleFunction('hasFormStart', array($this, 'hasFormStart'), array('needs_environment' => true)),
+		);
+	}
+
+	/**
+	 * @return boolean If the Twig function "form_start" is available.
+	 */
+	public function hasFormStart(\Twig_Environment $env) {
+		return $env->getFunction('form_start') !== false;
+	}
+
+}

--- a/Tests/IntegrationTestCase.php
+++ b/Tests/IntegrationTestCase.php
@@ -37,11 +37,10 @@ abstract class IntegrationTestCase extends WebTestCase {
 	/**
 	 * @param string $route
 	 * @param array $parameters
-	 * @param boolean $absolute
 	 * @return string URL
 	 */
-	protected function url($route, array $parameters = array(), $absolute = false) {
-		return static::$kernel->getContainer()->get('router')->generate($route, $parameters, $absolute);
+	protected function url($route, array $parameters = array()) {
+		return static::$kernel->getContainer()->get('router')->generate($route, $parameters);
 	}
 
 	/**

--- a/Tests/config/config.yml
+++ b/Tests/config/config.yml
@@ -2,6 +2,7 @@ imports:
   - { resource: "@CraueFormFlowBundle/Resources/config/form_flow.xml" }
   - { resource: "@IntegrationTestBundle/Resources/config/form_flow.xml" }
   - { resource: "@IntegrationTestBundle/Resources/config/form.xml" }
+  - { resource: "@IntegrationTestBundle/Resources/config/twig.xml" }
 
 framework:
   csrf_protection: ~

--- a/Twig/Extension/FormFlowExtension.php
+++ b/Twig/Extension/FormFlowExtension.php
@@ -24,11 +24,16 @@ class FormFlowExtension extends \Twig_Extension {
 	 * {@inheritDoc}
 	 */
 	public function getFilters() {
+		if (version_compare(\Twig_Environment::VERSION, '1.12', '<')) {
+			return array(
+				'craue_addDynamicStepNavigationParameter' => new \Twig_Filter_Method($this, 'addDynamicStepNavigationParameter'),
+				'craue_removeDynamicStepNavigationParameter' => new \Twig_Filter_Method($this, 'removeDynamicStepNavigationParameter'),
+			);
+		}
+
 		return array(
-			'craue_addDynamicStepNavigationParameter' =>
-					new \Twig_Filter_Method($this, 'addDynamicStepNavigationParameter'),
-			'craue_removeDynamicStepNavigationParameter' =>
-					new \Twig_Filter_Method($this, 'removeDynamicStepNavigationParameter'),
+			new \Twig_SimpleFilter('craue_addDynamicStepNavigationParameter', array($this, 'addDynamicStepNavigationParameter')),
+			new \Twig_SimpleFilter('craue_removeDynamicStepNavigationParameter', array($this, 'removeDynamicStepNavigationParameter')),
 		);
 	}
 
@@ -36,8 +41,14 @@ class FormFlowExtension extends \Twig_Extension {
 	 * {@inheritDoc}
 	 */
 	public function getFunctions() {
+		if (version_compare(\Twig_Environment::VERSION, '1.12', '<')) {
+			return array(
+				'craue_isStepLinkable' => new \Twig_Function_Method($this, 'isStepLinkable'),
+			);
+		}
+
 		return array(
-			'craue_isStepLinkable' => new \Twig_Function_Method($this, 'isStepLinkable'),
+			new \Twig_SimpleFunction('craue_isStepLinkable', array($this, 'isStepLinkable')),
 		);
 	}
 


### PR DESCRIPTION
At least with Symfony 2.7, I could get rid of all deprecation notices.

With 2.8, this won't be possible due to scopes. But there are two other notices I'm unable to track down yet ([Travis log](https://travis-ci.org/craue/CraueFormFlowBundle/jobs/94226353#L266)):
- **The value "false" for the "choices_as_values" option is deprecated since version 2.8 and will not be supported anymore in 3.0. Set this option to "true" and flip the contents of the "choices" option instead: 85x** although `choices_as_values` isn't used in the code at all.
- **The Symfony\Component\Form\ChoiceList\ArrayKeyChoiceList class is deprecated since version 2.8 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead: 1x** although `ArrayKeyChoiceList ` isn't used in the code at all.