### PR TITLE
add DoctrineStorage to store data in a Doctrine-managed database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION="2.6.*" SYMFONY_DEPRECATIONS_HELPER="666"
     - php: 5.6
+      env: SYMFONY_VERSION="2.7.*" SYMFONY__DB__DRIVER="pdo_sqlite"
+    - php: 5.6
       env: SYMFONY_VERSION="2.8.*"
     - php: 5.6
       env: SYMFONY_VERSION="3.0.*"

--- a/Storage/DoctrineStorage.php
+++ b/Storage/DoctrineStorage.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Craue\FormFlowBundle\Storage;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Stores data in a Doctrine-managed database.
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2016 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class DoctrineStorage implements StorageInterface {
+
+	const TABLE = 'craue_form_flow_storage';
+	const KEY_COLUMN = 'key';
+	const VALUE_COLUMN = 'value';
+
+	/**
+	 * @var Connection
+	 */
+	private $conn;
+
+	/**
+	 * @var StorageKeyGeneratorInterface
+	 */
+	private $storageKeyGenerator;
+
+	/**
+	 * @var AbstractSchemaManager
+	 */
+	private $schemaManager;
+
+	/**
+	 * @var string
+	 */
+	private $keyColumn;
+
+	/**
+	 * @var string
+	 */
+	private $valueColumn;
+
+	public function __construct(Connection $conn, StorageKeyGeneratorInterface $storageKeyGenerator) {
+		$this->conn = $conn;
+		$this->storageKeyGenerator = $storageKeyGenerator;
+		$this->schemaManager = $this->conn->getSchemaManager();
+		$this->keyColumn = $this->conn->quoteIdentifier(self::KEY_COLUMN);
+		$this->valueColumn = $this->conn->quoteIdentifier(self::VALUE_COLUMN);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function set($key, $value) {
+		if (!$this->tableExists()) {
+			$this->createTable();
+		}
+
+		if ($this->has($key)) {
+			$this->conn->update(self::TABLE, array(
+				$this->valueColumn => serialize($value),
+			), array(
+				$this->keyColumn => $this->generateKey($key),
+			));
+
+			return;
+		}
+
+		$this->conn->insert(self::TABLE, array(
+			$this->keyColumn => $this->generateKey($key),
+			$this->valueColumn => serialize($value),
+		));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get($key, $default = null) {
+		if (!$this->tableExists()) {
+			return $default;
+		}
+
+		$rawValue = $this->getRawValueForKey($key);
+
+		if ($rawValue === false) {
+			return $default;
+		}
+
+		return unserialize($rawValue);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function has($key) {
+		if (!$this->tableExists()) {
+			return false;
+		}
+
+		return $this->getRawValueForKey($key) !== false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function remove($key) {
+		if (!$this->tableExists()) {
+			return;
+		}
+
+		$removedValue = $this->get($key);
+
+		$this->conn->delete(self::TABLE, array(
+			$this->keyColumn => $this->generateKey($key),
+		));
+
+		return $removedValue;
+	}
+
+	/**
+	 * Gets stored raw data for the given key.
+	 * @param string $key
+	 * @return string|false Raw data or false, if no data is available.
+	 */
+	private function getRawValueForKey($key) {
+		$qb = $this->conn->createQueryBuilder()
+			->select($this->valueColumn)
+			->from(self::TABLE, 't') // alias needed only for DBAL < 2.5
+			->where($this->keyColumn . ' = :key')
+			->setParameter('key', $this->generateKey($key))
+		;
+
+		return $qb->execute()->fetchColumn();
+	}
+
+	private function tableExists() {
+		return $this->schemaManager->tablesExist(self::TABLE);
+	}
+
+	private function createTable() {
+		$table = new Table(self::TABLE, array(
+			new Column($this->keyColumn, Type::getType(Type::STRING)),
+			new Column($this->valueColumn, Type::getType(Type::TARRAY)),
+		));
+		$table->setPrimaryKey(array($this->keyColumn));
+		$this->schemaManager->createTable($table);
+	}
+
+	private function generateKey($key) {
+		return $this->storageKeyGenerator->generate($key);
+	}
+
+}

--- a/Storage/DoctrineStorage.php
+++ b/Storage/DoctrineStorage.php
@@ -114,13 +114,9 @@ class DoctrineStorage implements StorageInterface {
 			return;
 		}
 
-		$removedValue = $this->get($key);
-
 		$this->conn->delete(self::TABLE, array(
 			$this->keyColumn => $this->generateKey($key),
 		));
-
-		return $removedValue;
 	}
 
 	/**

--- a/Storage/SessionStorage.php
+++ b/Storage/SessionStorage.php
@@ -47,7 +47,7 @@ class SessionStorage implements StorageInterface {
 	 * {@inheritDoc}
 	 */
 	public function remove($key) {
-		return $this->session->remove($key);
+		$this->session->remove($key);
 	}
 
 }

--- a/Storage/StorageInterface.php
+++ b/Storage/StorageInterface.php
@@ -34,7 +34,6 @@ interface StorageInterface {
 	/**
 	 * Delete the stored data of the given key.
 	 * @param string $key
-	 * @return mixed The removed value.
 	 */
 	function remove($key);
 

--- a/Storage/StorageKeyGeneratorInterface.php
+++ b/Storage/StorageKeyGeneratorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Craue\FormFlowBundle\Storage;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2016 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+interface StorageKeyGeneratorInterface {
+
+	/**
+	 * Generates a complete storage key based on the key the storage received.
+	 * Usually, the given key would be appended to a user-unique identifier to achieve a session-like behavior.
+	 * @param string $key
+	 * @return string
+	 */
+	function generate($key);
+
+}

--- a/Storage/UserSessionStorageKeyGenerator.php
+++ b/Storage/UserSessionStorageKeyGenerator.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Craue\FormFlowBundle\Storage;
+
+use Craue\FormFlowBundle\Exception\InvalidTypeException;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * Generates a key unique for each user.
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2016 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class UserSessionStorageKeyGenerator implements StorageKeyGeneratorInterface {
+
+	/**
+	 * @var TokenStorageInterface
+	 */
+	private $tokenStorage;
+
+	/**
+	 * @var SessionInterface
+	 */
+	private $session;
+
+	public function __construct(TokenStorageInterface $tokenStorage, SessionInterface $session) {
+		$this->tokenStorage = $tokenStorage;
+		$this->session = $session;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function generate($key) {
+		if (!is_string($key)) {
+			throw new InvalidTypeException($key, 'string');
+		}
+
+		if (empty($key)) {
+			throw new \InvalidArgumentException('Argument must not be empty.');
+		}
+
+		$token = $this->tokenStorage->getToken();
+
+		if ($token instanceof TokenInterface && !$token instanceof AnonymousToken) {
+			$username = $token->getUsername();
+			if (!empty($username)) {
+				return sprintf('user_%s_%s', $username, $key);
+			}
+		}
+
+		// fallback to session id
+		if (!$this->session->isStarted()) {
+			$this->session->start();
+		}
+
+		return sprintf('session_%s_%s', $this->session->getId(), $key);
+	}
+
+}

--- a/Tests/AppKernel.php
+++ b/Tests/AppKernel.php
@@ -28,7 +28,9 @@ class AppKernel extends Kernel {
 	public function registerBundles() {
 		return array(
 			new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+			new \Symfony\Bundle\SecurityBundle\SecurityBundle(),
 			new \Symfony\Bundle\TwigBundle\TwigBundle(),
+			new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
 			new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
 			new \Craue\FormFlowBundle\CraueFormFlowBundle(),
 			new \Craue\FormFlowBundle\Tests\IntegrationTestBundle\IntegrationTestBundle(),

--- a/Tests/IntegrationTestBundle/DependencyInjection/Compiler/DoctrineStorageCompilerPass.php
+++ b/Tests/IntegrationTestBundle/DependencyInjection/Compiler/DoctrineStorageCompilerPass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle\DependencyInjection\Compiler;
+
+use Craue\FormFlowBundle\Storage\DoctrineStorage;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+
+/**
+ * Registration of services needed to use the {@link DoctrineStorage} implementation.
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2016 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class DoctrineStorageCompilerPass implements CompilerPassInterface {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function process(ContainerBuilder $container) {
+		if ($container->getParameter('db.driver') !== null) {
+			$loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../../Resources/config'));
+			$loader->load('doctrine_storage.xml');
+		}
+	}
+
+}

--- a/Tests/IntegrationTestBundle/DependencyInjection/StorageImplementationTest.php
+++ b/Tests/IntegrationTestBundle/DependencyInjection/StorageImplementationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle\DependencyInjection;
+
+use Craue\FormFlowBundle\Storage\StorageInterface;
+use Craue\FormFlowBundle\Tests\IntegrationTestBundle\DependencyInjection\Compiler\DoctrineStorageCompilerPass;
+use Craue\FormFlowBundle\Tests\IntegrationTestCase;
+
+/**
+ * @group integration
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2016 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class StorageImplementationTest extends IntegrationTestCase {
+
+	/**
+	 * Ensure that, depending on the configuration, the correct {@link StorageInterface} implementation is used.
+	 * This is useful because a compiler pass ({@link DoctrineStorageCompilerPass}) is needed to properly set up the
+	 * database connection and the storage service while relying on an DI extension to load the (overridden) service
+	 * may silently fail leading to a wrong implementation being used in tests.
+	 */
+	public function testUseCorrectStorageImplementation() {
+		$dbDriver = static::$kernel->getContainer()->getParameter('db.driver');
+		$storage = $this->getService('craue.form.flow.storage');
+		$expectedClass = $dbDriver !== null ? 'Craue\FormFlowBundle\Storage\DoctrineStorage' : 'Craue\FormFlowBundle\Storage\SessionStorage';
+		$this->assertInstanceOf($expectedClass, $storage);
+	}
+
+}

--- a/Tests/IntegrationTestBundle/IntegrationTestBundle.php
+++ b/Tests/IntegrationTestBundle/IntegrationTestBundle.php
@@ -2,6 +2,8 @@
 
 namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle;
 
+use Craue\FormFlowBundle\Tests\IntegrationTestBundle\DependencyInjection\Compiler\DoctrineStorageCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -10,4 +12,14 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @license http://opensource.org/licenses/mit-license.php MIT License
  */
 class IntegrationTestBundle extends Bundle {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function build(ContainerBuilder $container) {
+		parent::build($container);
+
+		$container->addCompilerPass(new DoctrineStorageCompilerPass());
+	}
+
 }

--- a/Tests/IntegrationTestBundle/Resources/config/doctrine_storage.xml
+++ b/Tests/IntegrationTestBundle/Resources/config/doctrine_storage.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+	Author: Christian Raue <christian.raue@gmail.com>
+	Copyright: 2011-2016 Christian Raue
+	License: http://opensource.org/licenses/mit-license.php MIT License
+-->
+<container xmlns="http://symfony.com/schema/dic/services"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+	<services>
+		<service id="craue.form.flow.storageKeyGenerator" class="Craue\FormFlowBundle\Storage\UserSessionStorageKeyGenerator">
+			<argument type="service" id="security.token_storage" />
+			<argument type="service" id="session" />
+		</service>
+
+		<service id="integrationTestBundle.doctrineConnection" class="Doctrine\DBAL\Connection" public="false">
+			<factory class="Doctrine\DBAL\DriverManager" method="getConnection" />
+			<argument type="collection">
+				<argument key="charset">UTF8</argument>
+				<argument key="driver">%db.driver%</argument>
+				<argument key="host">%db.host%</argument>
+				<argument key="port">%db.port%</argument>
+				<argument key="dbname">%db.name%</argument>
+				<argument key="user">%db.user%</argument>
+				<argument key="password">%db.password%</argument>
+				<argument key="path">%db.path%</argument>
+			</argument>
+		</service>
+
+		<service id="craue.form.flow.storage.doctrine" class="Craue\FormFlowBundle\Storage\DoctrineStorage" public="false">
+			<argument type="service" id="integrationTestBundle.doctrineConnection" />
+			<argument type="service" id="craue.form.flow.storageKeyGenerator" />
+		</service>
+
+		<service id="craue.form.flow.storage" alias="craue.form.flow.storage.doctrine" />
+	</services>
+
+</container>

--- a/Tests/IntegrationTestCase.php
+++ b/Tests/IntegrationTestCase.php
@@ -35,10 +35,18 @@ abstract class IntegrationTestCase extends WebTestCase {
 	}
 
 	/**
+	 * @param string $id The service identifier.
+	 * @return object The associated service.
+	 */
+	protected function getService($id) {
+		return static::$kernel->getContainer()->get($id);
+	}
+
+	/**
 	 * @return \Twig_Environment
 	 */
 	protected function getTwig() {
-		return static::$kernel->getContainer()->get('twig');
+		return $this->getService('twig');
 	}
 
 	/**
@@ -47,7 +55,7 @@ abstract class IntegrationTestCase extends WebTestCase {
 	 * @return string URL
 	 */
 	protected function url($route, array $parameters = array()) {
-		return static::$kernel->getContainer()->get('router')->generate($route, $parameters);
+		return $this->getService('router')->generate($route, $parameters);
 	}
 
 	/**

--- a/Tests/Storage/AbstractStorageTest.php
+++ b/Tests/Storage/AbstractStorageTest.php
@@ -65,12 +65,12 @@ abstract class AbstractStorageTest extends \PHPUnit_Framework_TestCase {
 
 	public function testRemove() {
 		$this->storage->set('foo', 'bar');
-		$this->assertSame('bar', $this->storage->remove('foo'));
+		$this->storage->remove('foo');
 		$this->assertFalse($this->storage->has('foo'));
 	}
 
 	public function testRemove_empty() {
-		$this->assertNull($this->storage->remove('foo'));
+		$this->storage->remove('foo');
 		$this->assertFalse($this->storage->has('foo'));
 	}
 

--- a/Tests/Storage/DoctrineStorageTest.php
+++ b/Tests/Storage/DoctrineStorageTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Craue\FormFlowBundle\Tests\Storage;
+
+use Craue\FormFlowBundle\Storage\DoctrineStorage;
+use Doctrine\DBAL\DriverManager;
+
+/**
+ * @group unit
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2016 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class DoctrineStorageTest extends AbstractStorageTest {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function getStorageImplementation() {
+		$conn = DriverManager::getConnection(array(
+			'driver' => 'pdo_sqlite',
+			'memory' => true,
+		));
+
+		$generator = $this->getMock('Craue\FormFlowBundle\Storage\StorageKeyGeneratorInterface');
+
+		$generator
+			->expects($this->any())
+			->method('generate')
+			->will($this->returnArgument(0))
+		;
+
+		return new DoctrineStorage($conn, $generator);
+	}
+
+	/**
+	 * Ensure that quoted data is properly handled by DBAL.
+	 * @dataProvider dataSetGet_stringsContainQuotes
+	 */
+	public function testSetGet_stringsContainQuotes($key, $value) {
+		$this->storage->set($key, $value);
+		$this->assertSame($value, $this->storage->get($key));
+	}
+
+	public function dataSetGet_stringsContainQuotes() {
+		return array(
+			array("f'oo", "b'ar"),
+			array('f"oo', 'b"ar'),
+		);
+	}
+
+}

--- a/Tests/Storage/UserSessionStorageKeyGeneratorTest.php
+++ b/Tests/Storage/UserSessionStorageKeyGeneratorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Craue\FormFlowBundle\Tests\Storage;
+
+use Craue\FormFlowBundle\Storage\StorageKeyGeneratorInterface;
+use Craue\FormFlowBundle\Storage\UserSessionStorageKeyGenerator;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
+use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\User;
+
+/**
+ * @group unit
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2016 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class UserSessionStorageKeyGeneratorTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @var StorageKeyGeneratorInterface
+	 */
+	protected $generator;
+
+	/**
+	 * @var TokenStorageInterface
+	 */
+	protected $tokenStorage;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp() {
+		$session = new Session(new MockArraySessionStorage());
+		$session->setId('12345');
+		$this->tokenStorage = new TokenStorage();
+		$this->generator = new UserSessionStorageKeyGenerator($this->tokenStorage, $session);
+	}
+
+	/**
+	 * @dataProvider dataGenerate_mockedTokens
+	 */
+	public function testGenerate_mockedTokens($expectedKey, $username) {
+		$token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AbstractToken')->setMethods(array('getUsername'))->getMockForAbstractClass();
+
+		$token
+			->expects($this->once())
+			->method('getUsername')
+			->will($this->returnValue($username))
+		;
+
+		$this->tokenStorage->setToken($token);
+		$this->assertSame($expectedKey, $this->generator->generate('key'));
+	}
+
+	public function dataGenerate_mockedTokens() {
+		return array(
+			array('session_12345_key', null),
+			array('session_12345_key', ''),
+			array('user_username_key', 'username'),
+		);
+	}
+
+	/**
+	 * @dataProvider dataGenerate_realTokens
+	 */
+	public function testGenerate_realTokens($expectedKey, $token) {
+		$this->tokenStorage->setToken($token);
+		$this->assertSame($expectedKey, $this->generator->generate('key'));
+	}
+
+	public function dataGenerate_realTokens() {
+		return array(
+			array('session_12345_key', null),
+			array('session_12345_key', new AnonymousToken('secret', '')),
+			array('session_12345_key', new AnonymousToken('secret', 'username')),
+			array('session_12345_key', new PreAuthenticatedToken('', 'password', 'firewall')),
+			array('user_username_key', new PreAuthenticatedToken('username', 'password', 'firewall')),
+			array('user_username_key', new RememberMeToken(new User('username', 'password'), 'firewall', 'secret')),
+			array('session_12345_key', new UsernamePasswordToken('', 'password', 'firewall')),
+			array('user_username_key', new UsernamePasswordToken('username', 'password', 'firewall')),
+			array('user_username_key', new UsernamePasswordToken(new User('username', 'password'), 'password', 'firewall')),
+		);
+	}
+
+	/**
+	 * @expectedException \Craue\FormFlowBundle\Exception\InvalidTypeException
+	 * @expectedExceptionMessage Expected argument of type "string", but "NULL" given.
+	 */
+	public function testGenerate_invalidArgument() {
+		$this->generator->generate(null);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage Argument must not be empty.
+	 */
+	public function testGenerate_emptyArgument() {
+		$this->generator->generate('');
+	}
+
+}

--- a/Tests/config/config.yml
+++ b/Tests/config/config.yml
@@ -2,6 +2,7 @@ imports:
   - { resource: "@CraueFormFlowBundle/Resources/config/form_flow.xml" }
   - { resource: "@IntegrationTestBundle/Resources/config/form_flow.xml" }
   - { resource: "@IntegrationTestBundle/Resources/config/form.xml" }
+  - { resource: parameters.php }
 
 framework:
   csrf_protection: ~
@@ -19,6 +20,15 @@ framework:
     fallback: en
   validation:
     enable_annotations: true
+
+security:
+  providers:
+    in_memory:
+      memory: ~
+  firewalls:
+    dummy:
+      pattern: .*
+      anonymous: ~
 
 twig:
   debug: "%kernel.debug%"

--- a/Tests/config/parameters.php
+++ b/Tests/config/parameters.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Only set parameters if they aren't already defined. This allows using environment variables (e.g. set by Travis) and fallback values.
+ * See http://symfony.com/doc/current/cookbook/configuration/external_parameters.html#environment-variables for details.
+ */
+
+$defaultParameters = array(
+	'db.driver' => null,
+// 	'db.driver' => 'pdo_mysql',
+// 	'db.driver' => 'pdo_sqlite',
+	'db.host' => '127.0.0.1',
+	'db.port' => null,
+	'db.name' => 'test',
+	'db.user' => 'travis',
+	'db.password' => null,
+	'db.path' => $container->getParameter('kernel.cache_dir') . '/sqlite.db',
+);
+
+foreach ($defaultParameters as $name => $value) {
+	if (!$container->hasParameter($name)) {
+		$container->setParameter($name, $value);
+	}
+}

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -213,6 +213,10 @@
 
 	- `type` to `formType`
 
+## Storage
+
+- The signature of method `remove` in `StorageInterface` has changed to not return the removed value anymore.
+
 ## Template
 
 - The Twig filters `craue_addDynamicStepNavigationParameter` and `craue_removeDynamicStepNavigationParameter` have been

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 	},
 	"require-dev": {
 		"doctrine/common": "~2.3",
+		"doctrine/doctrine-bundle": "~1.0",
 		"phpunit/phpunit": "~4.1|~5.0",
 		"sensio/framework-extra-bundle": "~3.0",
 		"symfony/phpunit-bridge": "^2.8.1|^3.0.1",


### PR DESCRIPTION
This will help people switching from session-based to Doctrine-based storage.

I wonder if it's worth breaking BC by changing `StorageInterface` to let the `remove` method not return the removed value anymore. Returning it was easy for `SessionStorage`, but it would require an additional query to fetch the value before removing it for the new `DoctrineStorage`. To avoid that, I'd like to change the interface.

Also, instead of adding a new Travis job to run the suite with SQLite, I'd prefer running all integration tests twice for each job, first with parameter `db.driver` set to `null` (for default session storage) and then set to `pdo_sqlite` (for Doctrine storage) in order to cover both setups in each environment. Is this possible?

I'd love to get feedback, especially from @havvg.