### PR TITLE
allow a callable for each step label

### DIFF
--- a/Form/Step.php
+++ b/Form/Step.php
@@ -18,7 +18,7 @@ class Step implements StepInterface {
 	protected $number;
 
 	/**
-	 * @var string|null
+	 * @var string|callable|null
 	 */
 	protected $label = null;
 
@@ -92,22 +92,33 @@ class Step implements StepInterface {
 	}
 
 	/**
-	 * @param string|null $label
+	 * @param string|callable|null $label
 	 */
 	public function setLabel($label) {
-		if ($label === null || is_string($label)) {
+		if ($label === null || is_string($label) || is_callable($label)) {
 			$this->label = $label;
 
 			return;
 		}
 
-		throw new InvalidTypeException($label, array('null', 'string'));
+		throw new InvalidTypeException($label, array('null', 'string', 'callable'));
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	public function getLabel() {
+		if (is_callable($this->label)) {
+			$returnValue = call_user_func($this->label);
+
+			if ($returnValue === null || is_string($returnValue)) {
+				return $returnValue;
+			}
+
+			throw new \RuntimeException(sprintf('The label callable for step %d did not return a string or null value.',
+					$this->number));
+		}
+
 		return $this->label;
 	}
 

--- a/README.md
+++ b/README.md
@@ -337,8 +337,9 @@ The array returned by that method is used to create all steps of the flow.
 The first item will be the first step. You can, however, explicitly index the array for easier readability.
 
 Valid options per step are:
-- `label` (`string`|`null`)
+- `label` (`string`|`callable`|`null`)
 	- If you'd like to render an overview of all steps you have to set the `label` option for each step.
+	- If using a callable, it has to return a string value or `null`.
 	- By default, the labels will be translated using the `messages` domain when rendered in Twig.
 - `form_type` (`FormTypeInterface`|`string`|`null`)
 	- The form type used to build the form for that step.


### PR DESCRIPTION
This would allow constructs like this:

```php
protected function loadStepsConfig() {
	$flow = $this;

	return array(
		array(
			'label' => function() use ($flow) {
				return $flow->getFormData()->isSpecial() ? 'special label' : 'default label';
			},
		),
	);
}
```