### PR TITLE
bump Symfony dependency to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,8 @@ env:
 
 matrix:
   include:
-    - php: 5.3.3
-      env: USE_DEPS="lowest"
-    - php: 5.6
-      env: SYMFONY_VERSION="2.6.*" SYMFONY_DEPRECATIONS_HELPER="666"
+    - php: 5.3
+      env: USE_DEPS="lowest" SYMFONY_DEPRECATIONS_HELPER="2"
     - php: 5.6
       env: SYMFONY_VERSION="2.7.*" SYMFONY__DB__DRIVER="pdo_sqlite"
     - php: 5.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - [#148]: restructured data storage
   - [#180]: renamed step config option `type` to `form_type`
   - [#184]: made the bundle Symfony 3 compatible, bumped Symfony dependency to 2.6
+  - [#222]: bumped Symfony dependency to 2.7
   - removed the step field template
   - renamed property `step` to `stepNumber` and method `getStep` to `getStepNumber` within event classes
 - [#98]+[#143]: add a validation error to the current form if a form of a previous step became invalid
@@ -51,6 +52,7 @@
 [#215]: https://github.com/craue/CraueFormFlowBundle/issues/215
 [#217]: https://github.com/craue/CraueFormFlowBundle/issues/217
 [#219]: https://github.com/craue/CraueFormFlowBundle/issues/219
+[#222]: https://github.com/craue/CraueFormFlowBundle/issues/222
 
 ## 2.1.9 (2015-12-29)
 

--- a/Form/Extension/FormFlowFormExtension.php
+++ b/Form/Extension/FormFlowFormExtension.php
@@ -5,7 +5,6 @@ namespace Craue\FormFlowBundle\Form\Extension;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * @author Konstantin Myakshin <koc-dp@yandex.ru>
@@ -34,14 +33,6 @@ class FormFlowFormExtension extends AbstractTypeExtension {
 			'flow_step',
 			'flow_step_key',
 		));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	// TODO remove as soon as Symfony >= 2.7 is required
-	public function setDefaultOptions(OptionsResolverInterface $resolver) {
-		$this->configureOptions($resolver);
 	}
 
 	/**

--- a/Form/Extension/FormFlowHiddenFieldExtension.php
+++ b/Form/Extension/FormFlowHiddenFieldExtension.php
@@ -6,7 +6,6 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * @author Konstantin Myakshin <koc-dp@yandex.ru>
@@ -33,14 +32,6 @@ class FormFlowHiddenFieldExtension extends AbstractTypeExtension {
 			'flow_instance_key',
 			'flow_step_key',
 		));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	// TODO remove as soon as Symfony >= 2.7 is required
-	public function setDefaultOptions(OptionsResolverInterface $resolver) {
-		$this->configureOptions($resolver);
 	}
 
 	/**

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ By default, if the flow's `getName` method returns `createVehicle`, such a group
 for the first step. You can customize this name by setting the flow's property `validationGroupPrefix` explicitly.
 The step number (1, 2, 3, etc.) will be appended by the flow.
 
-Compared to standalone forms, setting the `validation_groups` option in your form type's `setDefaultOptions`/`configureOptions`
+Compared to standalone forms, setting the `validation_groups` option in your form type's `configureOptions`
 method won't have any effect in the context of a flow. The value is just ignored, i.e. will be overwritten by the flow.
 But there are other ways of defining custom validation groups:
 

--- a/Tests/IntegrationTestBundle/Entity/RevalidatePreviousStepsData.php
+++ b/Tests/IntegrationTestBundle/Entity/RevalidatePreviousStepsData.php
@@ -3,6 +3,7 @@
 namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle\Entity;
 
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * @author Christian Raue <christian.raue@gmail.com>
@@ -20,8 +21,7 @@ class RevalidatePreviousStepsData {
 	/**
 	 * @Assert\Callback(groups={"flow_revalidatePreviousSteps_step1"})
 	 */
-	// TODO should be type-hinted with Symfony\Component\Validator\Context\ExecutionContextInterface, but tests fail with Symfony 2.6.4 and PHP 5.3.3, see https://travis-ci.org/craue/CraueFormFlowBundle/jobs/94383918#L249
-	public function isDataValid($context) {
+	public function isDataValid(ExecutionContextInterface $context) {
 		// valid only on first call
 		if (++self::$validationCalls > 1) {
 			$context->addViolation('Take this!');

--- a/Tests/IntegrationTestBundle/Form/CreateTopicForm.php
+++ b/Tests/IntegrationTestBundle/Form/CreateTopicForm.php
@@ -6,7 +6,6 @@ use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Entity\Topic;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * @author Christian Raue <christian.raue@gmail.com>
@@ -59,14 +58,6 @@ class CreateTopicForm extends AbstractType {
 		$resolver->setDefaults(array(
 			'isBugReport' => false,
 		));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	// TODO remove as soon as Symfony >= 2.7 is required
-	public function setDefaultOptions(OptionsResolverInterface $resolver) {
-		$this->configureOptions($resolver);
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -16,19 +16,18 @@
 		}
 	],
 	"require": {
-		"php": "^5.3.2|~7.0",
-		"symfony/form": "^2.6.4|~3.0",
-		"symfony/http-kernel": "^2.6.4|~3.0",
-		"symfony/translation": "^2.6.4|~3.0",
-		"symfony/yaml": "^2.6.4|~3.0"
+		"php": "^5.3.9|~7.0",
+		"symfony/form": "~2.7|~3.0",
+		"symfony/http-kernel": "~2.7|~3.0",
+		"symfony/translation": "~2.7|~3.0",
+		"symfony/yaml": "~2.7|~3.0"
 	},
 	"require-dev": {
-		"doctrine/common": "~2.3",
 		"doctrine/doctrine-bundle": "~1.0",
 		"phpunit/phpunit": "~4.1|~5.0",
 		"sensio/framework-extra-bundle": "~3.0",
 		"symfony/phpunit-bridge": "^2.8.1|^3.0.1",
-		"symfony/symfony": "^2.6.4|~3.0"
+		"symfony/symfony": "~2.7|~3.0"
 	},
 	"minimum-stability": "stable",
 	"autoload": {

--- a/travis_install_dependencies.sh
+++ b/travis_install_dependencies.sh
@@ -5,11 +5,6 @@ set -euv
 export COMPOSER_NO_INTERACTION=1
 composer self-update
 
-if [ "${TRAVIS_PHP_VERSION}" = "5.3.3" ]; then
-	composer config -g disable-tls true
-	composer config -g secure-http false
-fi
-
 if [ -n "${MIN_STABILITY:-}" ]; then
 	sed -i -e "s/\"minimum-stability\": \"stable\"/\"minimum-stability\": \"${MIN_STABILITY}\"/" composer.json
 fi


### PR DESCRIPTION
Follow-up to #184. Symfony 2.6 has already reached its end of life.