### PR TITLE
custom button labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,22 @@ Example with Bootstrap button classes:
 	} %}
 ```
 
+In the same manner you can customize the labels on the buttons:
+
+- `craue_formflow_button_label_finish` is basically the form __submit__ button
+- `craue_formflow_button_label_next` is the label of the __next__ button 
+- `craue_formflow_button_label_back` is the label of the __back__ button
+- `craue_formflow_button_label_reset` is the label of the __reset__ button 
+
+Example:
+
+```twig
+{% include 'CraueFormFlowBundle:FormFlow:buttons.html.twig' with {
+		craue_formflow_button_label_finish: finish_label | default('Submit'),
+		craue_formflow_button_label_reset: "Reset the Form"
+	} %}
+```
+
 ## Create an action
 
 ```php

--- a/README.md
+++ b/README.md
@@ -278,19 +278,20 @@ Example with Bootstrap button classes:
 	} %}
 ```
 
-In the same manner you can customize the labels on the buttons:
+In the same manner you can customize the button labels:
 
-- `craue_formflow_button_label_finish` is basically the form __submit__ button
-- `craue_formflow_button_label_next` is the label of the __next__ button 
-- `craue_formflow_button_label_back` is the label of the __back__ button
-- `craue_formflow_button_label_reset` is the label of the __reset__ button 
+- `craue_formflow_button_label_last` for either the __next__ or __finish__ button
+- `craue_formflow_button_label_finish` for the __finish__ button
+- `craue_formflow_button_label_next` for the __next__ button 
+- `craue_formflow_button_label_back` for the __back__ button
+- `craue_formflow_button_label_reset` for the __reset__ button 
 
 Example:
 
 ```twig
 {% include 'CraueFormFlowBundle:FormFlow:buttons.html.twig' with {
-		craue_formflow_button_label_finish: finish_label | default('Submit'),
-		craue_formflow_button_label_reset: "Reset the Form"
+		craue_formflow_button_label_finish: 'submit',
+		craue_formflow_button_label_reset: 'reset the flow',
 	} %}
 ```
 

--- a/Resources/views/FormFlow/buttons.html.twig
+++ b/Resources/views/FormFlow/buttons.html.twig
@@ -5,22 +5,23 @@
 		Thus, all buttons are defined in reverse order and will be reversed again via CSS.
 		See http://stackoverflow.com/questions/1963245/multiple-submit-buttons-specifying-default-button
 	#}
-	{%-
-		set craue_label = {
-			button_finish: craue_formflow_button_label_finish | default('button.finish'),
-			button_next: craue_formflow_button_label_next | default('button.next'),
-			button_back: craue_formflow_button_label_back | default('button.back'),
-			button_reset: craue_formflow_button_label_reset | default('button.reset')
-		}
-	-%}
+
 	{%- set isLastStep = flow.getCurrentStepNumber() == flow.getLastStepNumber() -%}
 	{%- set craue_formflow_button_class_last = craue_formflow_button_class_last | default('craue_formflow_button_last') -%}
 	{%- set craue_formflow_button_class_last = isLastStep
 			? craue_formflow_button_class_finish | default(craue_formflow_button_class_last)
 			: craue_formflow_button_class_next | default(craue_formflow_button_class_last)
 		-%}
+	{%- set craue_label = {
+			button_finish: craue_formflow_button_label_finish | default('button.finish'),
+			button_next: craue_formflow_button_label_next | default('button.next'),
+			button_back: craue_formflow_button_label_back | default('button.back'),
+			button_reset: craue_formflow_button_label_reset | default('button.reset'),
+		} -%}
+	{%- set craue_formflow_button_label_last = craue_formflow_button_label_last | default(isLastStep ? craue_label.button_finish : craue_label.button_next) -%}
+
 	<button type="submit" class="{{ craue_formflow_button_class_last }}">
-		{{- (isLastStep ? craue_label.button_finish : craue_label.button_next) | trans({}, 'CraueFormFlowBundle') -}}
+		{{- craue_formflow_button_label_last | trans({}, 'CraueFormFlowBundle') -}}
 	</button>
 
 	{% if renderBackButton %}

--- a/Resources/views/FormFlow/buttons.html.twig
+++ b/Resources/views/FormFlow/buttons.html.twig
@@ -5,7 +5,14 @@
 		Thus, all buttons are defined in reverse order and will be reversed again via CSS.
 		See http://stackoverflow.com/questions/1963245/multiple-submit-buttons-specifying-default-button
 	#}
-
+	{%-
+		set craue_label = {
+			button_finish: craue_formflow_button_label_finish | default('button.finish'),
+			button_next: craue_formflow_button_label_next | default('button.next'),
+			button_back: craue_formflow_button_label_back | default('button.back'),
+			button_reset: craue_formflow_button_label_reset | default('button.reset')
+		}
+	-%}
 	{%- set isLastStep = flow.getCurrentStepNumber() == flow.getLastStepNumber() -%}
 	{%- set craue_formflow_button_class_last = craue_formflow_button_class_last | default('craue_formflow_button_last') -%}
 	{%- set craue_formflow_button_class_last = isLastStep
@@ -13,16 +20,16 @@
 			: craue_formflow_button_class_next | default(craue_formflow_button_class_last)
 		-%}
 	<button type="submit" class="{{ craue_formflow_button_class_last }}">
-		{{- (isLastStep ? 'button.finish' : 'button.next') | trans({}, 'CraueFormFlowBundle') -}}
+		{{- (isLastStep ? craue_label.button_finish : craue_label.button_next) | trans({}, 'CraueFormFlowBundle') -}}
 	</button>
 
 	{% if renderBackButton %}
 		<button type="submit" class="{{ craue_formflow_button_class_back | default('') }}" name="{{ flow.getFormTransitionKey() }}" value="back" formnovalidate="formnovalidate">
-			{{- 'button.back' | trans({}, 'CraueFormFlowBundle') -}}
+			{{- craue_label.button_back | trans({}, 'CraueFormFlowBundle') -}}
 		</button>
 	{% endif %}
 
 	<button type="submit" class="{{ craue_formflow_button_class_reset | default('craue_formflow_button_first') }}" name="{{ flow.getFormTransitionKey() }}" value="reset" formnovalidate="formnovalidate">
-		{{- 'button.reset' | trans({}, 'CraueFormFlowBundle') -}}
+		{{- craue_label.button_reset | trans({}, 'CraueFormFlowBundle') -}}
 	</button>
 </div>

--- a/Tests/Resources/TemplateRenderingTest.php
+++ b/Tests/Resources/TemplateRenderingTest.php
@@ -200,6 +200,116 @@ class TemplateRenderingTest extends IntegrationTestCase {
 		$this->assertContains('<button type="submit" class="reset" name="flow_renderingTest_transition" value="reset" formnovalidate="formnovalidate">start over</button>', $renderedTemplate);
 	}
 
+	public function testCustomNextButtonLabel() {
+		$flow = $this->getFlowStub(array(), array(
+			array(
+				'label' => 'step1',
+			),
+			array(
+				'label' => 'step2',
+			),
+		));
+
+		$flow->nextStep();
+
+		$renderedTemplate = $this->getTwig()->render(self::BUTTONS_TEMPLATE, array(
+			'flow' => $flow,
+			'craue_formflow_button_label_next' => 'custom next',
+		));
+
+		$this->assertContains('<button type="submit" class="craue_formflow_button_last">custom next</button>', $renderedTemplate);
+	}
+
+	public function testCustomFinishButtonLabel() {
+		$flow = $this->getFlowStub(array(), array(
+			array(
+				'label' => 'step1',
+			),
+		));
+
+		$flow->nextStep();
+
+		$renderedTemplate = $this->getTwig()->render(self::BUTTONS_TEMPLATE, array(
+			'flow' => $flow,
+			'craue_formflow_button_label_finish' => 'custom finish',
+		));
+
+		$this->assertContains('<button type="submit" class="craue_formflow_button_last">custom finish</button>', $renderedTemplate);
+	}
+
+	public function testCustomLastButtonLabel() {
+		$flow = $this->getFlowStub(array(), array(
+			array(
+				'label' => 'step1',
+			),
+		));
+
+		$flow->nextStep();
+
+		$renderedTemplate = $this->getTwig()->render(self::BUTTONS_TEMPLATE, array(
+			'flow' => $flow,
+			'craue_formflow_button_label_last' => 'custom last',
+		));
+
+		$this->assertContains('<button type="submit" class="craue_formflow_button_last">custom last</button>', $renderedTemplate);
+
+		$flow = $this->getFlowStub(array(), array(
+			array(
+				'label' => 'step1',
+			),
+			array(
+				'label' => 'step2',
+			),
+		));
+
+		$flow->nextStep();
+
+		$renderedTemplate = $this->getTwig()->render(self::BUTTONS_TEMPLATE, array(
+			'flow' => $flow,
+			'craue_formflow_button_label_last' => 'custom last',
+		));
+
+		$this->assertContains('<button type="submit" class="craue_formflow_button_last">custom last</button>', $renderedTemplate);
+	}
+
+	public function testCustomBackButtonLabel() {
+		$flow = $this->getFlowStub(array(), array(
+			array(
+				'label' => 'step1',
+			),
+			array(
+				'label' => 'step2',
+			),
+		));
+
+		$flow->nextStep();
+		$flow->nextStep();
+
+		$renderedTemplate = $this->getTwig()->render(self::BUTTONS_TEMPLATE, array(
+			'flow' => $flow,
+			'craue_formflow_button_label_back' => 'custom back',
+		));
+
+		$this->assertContains('<button type="submit" class="" name="flow_renderingTest_transition" value="back" formnovalidate="formnovalidate">custom back</button>', $renderedTemplate);
+	}
+
+	public function testCustomResetButtonLabel() {
+		$flow = $this->getFlowStub(array(), array(
+			array(
+				'label' => 'step1',
+			),
+		));
+
+		$flow->nextStep();
+
+		$renderedTemplate = $this->getTwig()->render(self::BUTTONS_TEMPLATE, array(
+			'flow' => $flow,
+			'craue_formflow_button_label_reset' => 'custom reset',
+		));
+
+		$this->assertContains('<button type="submit" class="craue_formflow_button_first" name="flow_renderingTest_transition" value="reset" formnovalidate="formnovalidate">custom reset</button>', $renderedTemplate);
+	}
+
 	public function testStepList() {
 		$flow = $this->getFlowStub();
 


### PR DESCRIPTION
Replaces and closes #200.

What I did here:
- squashed the commits of #200
- added variable `craue_formflow_button_label_last` to be in sync with `craue_formflow_button_class_last` added by #126
- added tests
- updated the docs

@pculka, ok?