### PR TITLE
added `StepLabel` class to avoid issues with labels that are also PHP function names

### DIFF
--- a/Exception/StepLabelCallableInvalidReturnValueException.php
+++ b/Exception/StepLabelCallableInvalidReturnValueException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Craue\FormFlowBundle\Exception;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2016 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class StepLabelCallableInvalidReturnValueException extends \RuntimeException {
+}

--- a/Form/StepLabel.php
+++ b/Form/StepLabel.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Craue\FormFlowBundle\Form;
+
+use Craue\FormFlowBundle\Exception\InvalidTypeException;
+use Craue\FormFlowBundle\Exception\StepLabelCallableInvalidReturnValueException;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2016 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class StepLabel {
+
+	/**
+	 * @var boolean If <code>$value</code> is callable.
+	 */
+	private $callable;
+
+	/**
+	 * @var string|callable|null
+	 */
+	private $value = null;
+
+	/**
+	 * @param string|null $value
+	 */
+	public static function createStringLabel($value) {
+		return new static($value);
+	}
+
+	/**
+	 * @param callable $value
+	 */
+	public static function createCallableLabel($value) {
+		return new static($value, true);
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getText() {
+		if ($this->callable) {
+			$returnValue = call_user_func($this->value);
+
+			if ($returnValue === null || is_string($returnValue)) {
+				return $returnValue;
+			}
+
+			throw new StepLabelCallableInvalidReturnValueException();
+		}
+
+		return $this->value;
+	}
+
+	/**
+	 * @param string|callable|null $value
+	 * @param boolean $callable
+	 */
+	private function __construct($value, $callable = false) {
+		$this->setValue($value, $callable);
+	}
+
+	/**
+	 * @param string|callable|null $value
+	 * @param boolean $callable
+	 */
+	private function setValue($value, $callable = false) {
+		if ($callable) {
+			if (!is_callable($value)) {
+				throw new InvalidTypeException($value, array('callable'));
+			}
+		} else {
+			if ($value !== null && !is_string($value)) {
+				throw new InvalidTypeException($value, array('null', 'string'));
+			}
+		}
+
+		$this->callable = $callable;
+		$this->value = $value;
+	}
+
+}

--- a/README.md
+++ b/README.md
@@ -355,9 +355,9 @@ The array returned by that method is used to create all steps of the flow.
 The first item will be the first step. You can, however, explicitly index the array for easier readability.
 
 Valid options per step are:
-- `label` (`string`|`callable`|`null`)
+- `label` (`string`|`StepLabel`|`null`)
 	- If you'd like to render an overview of all steps you have to set the `label` option for each step.
-	- If using a callable, it has to return a string value or `null`.
+	- If using a callable on a `StepLabel` instance, it has to return a string value or `null`.
 	- By default, the labels will be translated using the `messages` domain when rendered in Twig.
 - `form_type` (`FormTypeInterface`|`string`|`null`)
 	- The form type used to build the form for that step.
@@ -397,7 +397,7 @@ protected function loadStepsConfig() {
 			'form_type' => 'MyCompany\MyBundle\Form\CreateVehicleStep1Form',
 		),
 		2 => array(
-			'label' => 'engine',
+			'label' => StepLabel::createCallableLabel(function() { return 'engine'; })
 			'form_type' => 'MyCompany\MyBundle\Form\CreateVehicleStep2Form',
 			'form_options' => array(
 				'validation_groups' => array('Default'),

--- a/Tests/Form/StepLabelTest.php
+++ b/Tests/Form/StepLabelTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Craue\FormFlowBundle\Tests\Form;
+
+use Craue\FormFlowBundle\Form\StepLabel;
+use Craue\FormFlowBundle\Tests\UnitTestCase;
+
+/**
+ * @group unit
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2016 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class StepLabelTest extends UnitTestCase {
+
+	/**
+	 * @dataProvider dataCreateStringLabel
+	 */
+	public function testCreateStringLabel($value) {
+		$this->assertSame($value, StepLabel::createStringLabel($value)->getText());
+	}
+
+	public function dataCreateStringLabel() {
+		return array(
+			array('label'),
+			array('date'),
+			array(null),
+		);
+	}
+
+	/**
+	 * @dataProvider dataCreateStringLabel_invalidArgument
+	 * @expectedException \Craue\FormFlowBundle\Exception\InvalidTypeException
+	 */
+	public function testCreateStringLabel_invalidArgument($value) {
+		StepLabel::createStringLabel($value);
+	}
+
+	public function dataCreateStringLabel_invalidArgument() {
+		return array(
+			array(true),
+			array(1.1),
+			array(function() { return 'country'; }),
+		);
+	}
+
+	/**
+	 * @dataProvider dataCreateCallableLabel
+	 */
+	public function testCreateCallableLabel($value, $expectedText) {
+		$this->assertSame($expectedText, StepLabel::createCallableLabel($value)->getText());
+	}
+
+	public function dataCreateCallableLabel() {
+		return array(
+			array('Craue\FormFlowBundle\Tests\Form\StepLabelTest::_returnString', 'label'),
+			array('Craue\FormFlowBundle\Tests\Form\StepLabelTest::_returnNull', null),
+			array(function() { return 'label'; }, 'label'),
+		);
+	}
+
+	/**
+	 * @dataProvider dataCreateCallableLabel_invalidArgument
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testCreateCallableLabel_invalidArgument($value) {
+		StepLabel::createCallableLabel($value)->getText();
+	}
+
+	public function dataCreateCallableLabel_invalidArgument() {
+		return array(
+			array('label'),
+			array('UnknownClass::unknownMethod'),
+			array(null),
+		);
+	}
+
+	/**
+	 * @dataProvider dataGetText_callableInvalidReturnValue
+	 * @expectedException Craue\FormFlowBundle\Exception\StepLabelCallableInvalidReturnValueException
+	 */
+	public function testGetText_callableInvalidReturnValue($value) {
+		StepLabel::createCallableLabel($value)->getText();
+	}
+
+	public function dataGetText_callableInvalidReturnValue() {
+		return array(
+			array('Craue\FormFlowBundle\Tests\Form\StepLabelTest::_returnOne'),
+			array(function() { return 1; }),
+		);
+	}
+
+	public static function _returnString() {
+		return 'label';
+	}
+
+	public static function _returnNull() {
+		return;
+	}
+
+	public static function _returnOne() {
+		return 1;
+	}
+
+}

--- a/Tests/Form/StepTest.php
+++ b/Tests/Form/StepTest.php
@@ -4,6 +4,7 @@ namespace Craue\FormFlowBundle\Tests\Form;
 
 use Craue\FormFlowBundle\Form\FormFlowInterface;
 use Craue\FormFlowBundle\Form\Step;
+use Craue\FormFlowBundle\Form\StepLabel;
 use Craue\FormFlowBundle\Tests\UnitTestCase;
 
 /**
@@ -33,9 +34,9 @@ class StepTest extends UnitTestCase {
 		$this->assertEquals('country', $step->getLabel());
 
 		$step = Step::createFromConfig(1, array(
-			'label' => function() {
+			'label' => StepLabel::createCallableLabel(function() {
 				return 'country';
-			},
+			}),
 		));
 		$this->assertEquals('country', $step->getLabel());
 
@@ -131,6 +132,7 @@ class StepTest extends UnitTestCase {
 	public function dataSetGetLabel() {
 		return array(
 			array('label'),
+			array('date'),
 			array(null),
 		);
 	}
@@ -151,9 +153,9 @@ class StepTest extends UnitTestCase {
 		;
 
 		$step = Step::createFromConfig(1, array(
-			'label' => function() use ($flow) {
+			'label' => StepLabel::createCallableLabel(function() use ($flow) {
 				return $flow->getFormData() === 'special' ? 'special label' : 'default label';
-			},
+			}),
 		));
 
 		$this->assertSame('special label', $step->getLabel());
@@ -206,6 +208,7 @@ class StepTest extends UnitTestCase {
 		return array(
 			array(true),
 			array(1.1),
+			array(function() { return 'label'; }),
 		);
 	}
 
@@ -331,9 +334,9 @@ class StepTest extends UnitTestCase {
 
 	protected function createStepWithLabelCallable($number, $returnValue) {
 		return Step::createFromConfig($number, array(
-			'label' => function() use ($returnValue) {
+			'label' => StepLabel::createCallableLabel(function() use ($returnValue) {
 				return $returnValue;
-			},
+			}),
 		));
 	}
 


### PR DESCRIPTION
replaces #237, fixes #236

Instead of

```php
'label' => function() {
	return 'country';
},
```

now

```php
'label' => StepLabel::createCallableLabel(function() {
	return 'country';
}),
```

has to be used.

@fracsi, what do you think of this?