### PR TITLE
Hotfix assetic dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /vendors-install.bat
 /vendors-update.bat
 /vendors-whatsnew.bat
+nbproject

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ in a shell.
 public function registerBundles() {
 	$bundles = array(
 		// ...
+		new Symfony\Bundle\AsseticBundle\AsseticBundle(),
 		new Craue\FormFlowBundle\CraueFormFlowBundle(),
 	);
 	// ...

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 		"symfony/form": "~2.7|~3.0",
 		"symfony/http-kernel": "~2.7|~3.0",
 		"symfony/translation": "~2.7|~3.0",
-		"symfony/yaml": "~2.7|~3.0"
+		"symfony/yaml": "~2.7|~3.0",
+                "symfony/assetic-bundle": "2.7.*"
 	},
 	"require-dev": {
 		"doctrine/doctrine-bundle": "~1.0",


### PR DESCRIPTION
 As of symfony 2.8 assetic is no more included in the core package