### PR TITLE
Hotfix assetic dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.buildpath
 /.project
 /.settings
+/nbproject
 /composer-install.bat
 /composer-update.bat
 /composer.lock

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ in a shell.
 public function registerBundles() {
 	$bundles = array(
 		// ...
+		new Symfony\Bundle\AsseticBundle\AsseticBundle(),
 		new Craue\FormFlowBundle\CraueFormFlowBundle(),
 	);
 	// ...

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 	"require": {
 		"php": "^5.3.2|~7.0",
 		"symfony/form": "^2.1.3",
-		"symfony/framework-bundle": "^2.1.3"
+		"symfony/framework-bundle": "^2.1.3",
+                "symfony/assetic-bundle": "^2.8"
 	},
 	"require-dev": {
 		"doctrine/common": "~2.3",


### PR DESCRIPTION
Assetic is no longer part of symfony core as of 2.8. 
It is needed for navigation buttons styling as recommended in this section of docs:
https://github.com/craue/CraueFormFlowBundle#create-a-form-template
