### PR TITLE
Add an option for removing the reset button

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ In the same manner you can customize the button labels:
 - `craue_formflow_button_label_finish` for the __finish__ button
 - `craue_formflow_button_label_next` for the __next__ button 
 - `craue_formflow_button_label_back` for the __back__ button
-- `craue_formflow_button_label_reset` for the __reset__ button 
+- `craue_formflow_button_label_reset` for the __reset__ button
 
 Example:
 
@@ -294,6 +294,8 @@ Example:
 		craue_formflow_button_label_reset: 'reset the flow',
 	} %}
 ```
+
+You can also remove the reset button by setting `craue_formflow_button_render_reset` to `false`.
 
 ## Create an action
 

--- a/Resources/views/FormFlow/buttons.html.twig
+++ b/Resources/views/FormFlow/buttons.html.twig
@@ -1,5 +1,8 @@
 {% set renderBackButton = flow.getFirstStepNumber() < flow.getLastStepNumber() and flow.getCurrentStepNumber() in (flow.getFirstStepNumber() + 1) .. flow.getLastStepNumber() %}
-<div class="craue_formflow_buttons craue_formflow_button_count_{% if renderBackButton %}3{% else %}2{% endif %}">
+{% set renderResetButton = craue_formflow_button_render_reset is defined ? craue_formflow_button_render_reset : true %}
+{% set buttonCount = 1 + (renderBackButton ? 1 : 0) + (renderResetButton ? 1 : 0) %}
+
+<div class="craue_formflow_buttons craue_formflow_button_count_{{ buttonCount }}">
 	{#
 		Default button (the one trigged by pressing the enter/return key) must be defined first.
 		Thus, all buttons are defined in reverse order and will be reversed again via CSS.
@@ -31,7 +34,7 @@
 			},
 			{
 				label: craue_formflow_button_label_reset | default('button.reset'),
-				render: true,
+				render: renderResetButton,
 				attr: {
 					class: craue_formflow_button_class_reset | default('craue_formflow_button_first'),
 					name: flow.getFormTransitionKey(),

--- a/Tests/Resources/TemplateRenderingTest.php
+++ b/Tests/Resources/TemplateRenderingTest.php
@@ -48,6 +48,30 @@ class TemplateRenderingTest extends IntegrationTestCase {
 		$this->assertContains('<button type="submit" class="craue_formflow_button_first" name="flow_renderingTest_transition" value="reset" formnovalidate="formnovalidate">start over</button>', $renderedTemplate);
 	}
 
+	public function testButtons_noResetButton() {
+		$flow = $this->getFlowStub();
+
+		// first step
+		$flow->nextStep();
+
+		$renderedTemplate = $this->getTwig()->render(self::BUTTONS_TEMPLATE, array(
+			'craue_formflow_button_render_reset' => false,
+			'flow' => $flow,
+		));
+		$this->assertContains('<div class="craue_formflow_buttons craue_formflow_button_count_1">', $renderedTemplate);
+		$this->assertNotContains('<button type="submit" class="craue_formflow_button_first" name="flow_renderingTest_transition" value="reset" formnovalidate="formnovalidate">start over</button>', $renderedTemplate);
+
+		// second step
+		$flow->nextStep();
+
+		$renderedTemplate = $this->getTwig()->render(self::BUTTONS_TEMPLATE, array(
+			'craue_formflow_button_render_reset' => false,
+			'flow' => $flow,
+		));
+		$this->assertContains('<div class="craue_formflow_buttons craue_formflow_button_count_2">', $renderedTemplate);
+		$this->assertNotContains('<button type="submit" class="craue_formflow_button_first" name="flow_renderingTest_transition" value="reset" formnovalidate="formnovalidate">start over</button>', $renderedTemplate);
+	}
+
 	public function testButtons_firstStepSkipped() {
 		$flow = $this->getFlowStub(array(), array(
 			array(


### PR DESCRIPTION
This feature adds an option to remove the reset button because this one is not always necessary.

To remove it, we need to pass an option named `craue_formflow_render_reset_button` when include `CraueFormFlowBundle:FormFlow:buttons.html.twig`.

Exemple:
```
{% include 'CraueFormFlowBundle:FormFlow:buttons.html.twig' with {
        craue_formflow_button_class_last: 'btn btn-primary',
        craue_formflow_button_class_back: 'btn btn-default',
        craue_formflow_button_class_reset: 'btn btn-warning',
        craue_formflow_render_reset_button: false
} %}
```
