### PR TITLE
refactor(flow): change loadStepsConfig to abstract method

### DIFF
--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -975,9 +975,7 @@ abstract class FormFlow implements FormFlowInterface {
 	 * Defines the configuration for all steps of this flow.
 	 * @return array
 	 */
-	protected function loadStepsConfig() {
-		return array();
-	}
+	 abstract protected function loadStepsConfig();
 
 	protected function retrieveStepData() {
 		return $this->dataManager->load($this);


### PR DESCRIPTION
Change the method loadStepsConfig to abstract method which should be always implemented in the specific flow.

Closes #287