### PR TITLE
Update travis.yml with PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 env:
   - SYMFONY_VERSION='2.7.*'


### PR DESCRIPTION
Added PHP 7.1 to `travis.yml` in order to test the codebase against PHP 7.1