### PR TITLE
use FormFlowInterface in TwigExtension instead of concrete class

### DIFF
--- a/Twig/Extension/FormFlowExtension.php
+++ b/Twig/Extension/FormFlowExtension.php
@@ -2,7 +2,6 @@
 
 namespace Craue\FormFlowBundle\Twig\Extension;
 
-use Craue\FormFlowBundle\Form\FormFlow;
 use Craue\FormFlowBundle\Util\FormFlowUtil;
 
 /**
@@ -55,30 +54,30 @@ class FormFlowExtension extends \Twig_Extension {
 	/**
 	 * Adds route parameters for dynamic step navigation.
 	 * @param array $parameters Current route parameters.
-	 * @param FormFlow $flow The flow involved.
+	 * @param FormFlowInterface $flow The flow involved.
 	 * @param int $stepNumber Number of the step the link will be generated for.
 	 * @return array Route parameters plus instance and step parameter.
 	 */
-	public function addDynamicStepNavigationParameters(array $parameters, FormFlow $flow, $stepNumber) {
+	public function addDynamicStepNavigationParameters(array $parameters, FormFlowInterface $flow, $stepNumber) {
 		return $this->formFlowUtil->addRouteParameters($parameters, $flow, $stepNumber);
 	}
 
 	/**
 	 * Removes route parameters for dynamic step navigation.
 	 * @param array $parameters Current route parameters.
-	 * @param FormFlow $flow The flow involved.
+	 * @param FormFlowInterface $flow The flow involved.
 	 * @return array Route parameters without instance and step parameter.
 	 */
-	public function removeDynamicStepNavigationParameters(array $parameters, FormFlow $flow) {
+	public function removeDynamicStepNavigationParameters(array $parameters, FormFlowInterface $flow) {
 		return $this->formFlowUtil->removeRouteParameters($parameters, $flow);
 	}
 
 	/**
-	 * @param FormFlow $flow The flow involved.
+	 * @param FormFlowInterface $flow The flow involved.
 	 * @param int $stepNumber Number of the step the link will be generated for.
 	 * @return bool If the step can be linked to.
 	 */
-	public function isStepLinkable(FormFlow $flow, $stepNumber) {
+	public function isStepLinkable(FormFlowInterface $flow, $stepNumber) {
 		if (!$flow->isAllowDynamicStepNavigation()
 				|| $flow->getCurrentStepNumber() === $stepNumber
 				|| $flow->isStepSkipped($stepNumber)) {
@@ -105,12 +104,12 @@ class FormFlowExtension extends \Twig_Extension {
 
 	// methods for BC with third-party templates (e.g. MopaBootstrapBundle)
 
-	public function addDynamicStepNavigationParameter(array $parameters, FormFlow $flow, $stepNumber) {
+	public function addDynamicStepNavigationParameter(array $parameters, FormFlowInterface $flow, $stepNumber) {
 		@trigger_error('Twig filter craue_addDynamicStepNavigationParameter is deprecated since version 3.0. Use filter craue_addDynamicStepNavigationParameters instead.', E_USER_DEPRECATED);
 		return $this->addDynamicStepNavigationParameters($parameters, $flow, $stepNumber);
 	}
 
-	public function removeDynamicStepNavigationParameter(array $parameters, FormFlow $flow) {
+	public function removeDynamicStepNavigationParameter(array $parameters, FormFlowInterface $flow) {
 		@trigger_error('Twig filter craue_removeDynamicStepNavigationParameter is deprecated since version 3.0. Use filter craue_removeDynamicStepNavigationParameters instead.', E_USER_DEPRECATED);
 		return $this->removeDynamicStepNavigationParameters($parameters, $flow);
 	}


### PR DESCRIPTION
If one wants to overwrite the FormFlow class or implement his own implementation, the original TwigExtension will work out of the box