### PR TITLE
Exclude tests from Composer's classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,10 @@
 	"autoload": {
 		"psr-4": {
 			"Craue\\FormFlowBundle\\": ""
-		}
+		},
+		"exclude-from-classmap": [
+			"/Tests/"
+		]
 	},
 	"extra": {
 		"branch-alias": {


### PR DESCRIPTION
This is a little performance improvement. If the optimised dumped classmap is generated, the tests should not be part of it. Excluding unit tests is [very common in Symfony's bundles](https://github.com/symfony/filesystem/blob/master/composer.json#L23-L25)

Documentation: https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps