### PR TITLE
Fix form extension deprecation SF4

### DIFF
--- a/Form/Extension/FormFlowFormExtension.php
+++ b/Form/Extension/FormFlowFormExtension.php
@@ -23,6 +23,10 @@ class FormFlowFormExtension extends AbstractTypeExtension {
 		return $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
 	}
 
+	public static function getExtendedTypes() {
+		return array('Symfony\Component\Form\Extension\Core\Type\FormType');
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */

--- a/Form/Extension/FormFlowHiddenFieldExtension.php
+++ b/Form/Extension/FormFlowHiddenFieldExtension.php
@@ -24,6 +24,10 @@ class FormFlowHiddenFieldExtension extends AbstractTypeExtension {
 		return $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType' : 'hidden';
 	}
 
+	public static function getExtendedTypes() {
+		return array('Symfony\Component\Form\Extension\Core\Type\HiddenType');
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */


### PR DESCRIPTION
Since 4.2 the The `getExtendedType()` method of the `FormTypeExtensionInterface` is deprecated, it should implement the static `getExtendedTypes()` method instead: https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#form