### PR TITLE
Add the default validation group when no group specified

### DIFF
--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\Constraint;
 
 /**
  * @author Christian Raue <christian.raue@gmail.com>
@@ -785,7 +786,7 @@ abstract class FormFlow implements FormFlowInterface {
 
 		// add the generated step-based validation group, unless it's explicitly set to false, a closure, or a GroupSequence
 		if (!array_key_exists('validation_groups', $options)) {
-			$options['validation_groups'] = [$this->getValidationGroupPrefix() . $step];
+			$options['validation_groups'] = [Constraint::DEFAULT_GROUP, $this->getValidationGroupPrefix() . $step];
 		} else {
 			$vg = $options['validation_groups'];
 

--- a/Tests/Form/FormFlowTest.php
+++ b/Tests/Form/FormFlowTest.php
@@ -146,7 +146,7 @@ class FormFlowTest extends UnitTestCase {
 
 		$options = $flow->getFormOptions(1);
 
-		$this->assertEquals(['flow_createTopic_step1'], $options['validation_groups']);
+		$this->assertEquals(['Default', 'flow_createTopic_step1'], $options['validation_groups']);
 	}
 
 	public function testGetStepsDoneRemaining() {


### PR DESCRIPTION
When no validation group specified the cascade validation does not work because the default validation group is not set.