### PR TITLE
Invert TranslatorInterface feature detection logic

### DIFF
--- a/EventListener/FlowExpiredEventListener.php
+++ b/EventListener/FlowExpiredEventListener.php
@@ -34,7 +34,7 @@ abstract class BaseFlowExpiredEventListener {
 }
 
 // TODO revert to one clean class definition as soon as Symfony >= 4.2 is required
-if (!interface_exists(LegacyTranslatorInterface::class)) {
+if (interface_exists(TranslatorInterface::class)) {
 	/**
 	 * Adds a validation error to the current step's form if an expired flow is detected.
 	 *

--- a/EventListener/PreviousStepInvalidEventListener.php
+++ b/EventListener/PreviousStepInvalidEventListener.php
@@ -35,7 +35,7 @@ abstract class BasePreviousStepInvalidEventListener {
 }
 
 // TODO revert to one clean class definition as soon as Symfony >= 4.2 is required
-if (!interface_exists(LegacyTranslatorInterface::class)) {
+if (interface_exists(TranslatorInterface::class)) {
 	/**
 	 * Adds a validation error to the current step's form if revalidating previous steps failed.
 	 *


### PR DESCRIPTION
This PR inverts the feature detection logic for the `TranslatorInterface` - so instead of testing for the non-existence of the old interface from `Symfony\Components` this now checks if the one from `Symfony\Contracts` exists.

The idea behind this change is that the detection fails if you're using a polyfill (for instance https://github.com/contao/polyfill-symfony/blob/main/src/TranslatorInterface.php). We're using this over at Contao CMS to ease providing bundles that are compatible with multiple Symfony versions.

Otherwise, you will get an error like this in this case you're using Symfony 5 (the `DataCollectorTranslator` implements the new interface): 
```
 Craue\FormFlowBundle\EventListener\FlowExpiredEventListener::setTranslator():
 Argument #1 ($translator) must be of type Symfony\Component\Translation\TranslatorInterface, Contao\CoreBundle\Translation\DataCollectorTranslator given
```