### PR TITLE
fix: merge handled files within collections to correct index

### DIFF
--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -714,7 +714,7 @@ abstract class FormFlow implements FormFlowInterface {
 		}
 
 		if ($this->handleFileUploads) {
-			$currentStepData = array_merge_recursive($currentStepData, $request->files->get($formName, []));
+			$currentStepData = array_replace_recursive($currentStepData, $request->files->get($formName, []));
 		}
 
 		$stepData[$this->getCurrentStepNumber()] = $currentStepData;

--- a/Tests/IntegrationTestBundle/Controller/FormFlowController.php
+++ b/Tests/IntegrationTestBundle/Controller/FormFlowController.php
@@ -137,13 +137,13 @@ class FormFlowController extends AbstractController {
 				'@IntegrationTest/FormFlow/photoUpload.html.twig');
 	}
 
-    /**
-     * @Route("/photoCollectionUpload/", name="_FormFlow_photoCollectionUpload")
-     */
-    public function photoCollectionUploadAction() {
-        return $this->processFlow(new PhotoCollection(), $this->get(PhotoCollectionUploadFlow::class),
-            '@IntegrationTest/FormFlow/photoCollectionUpload.html.twig');
-    }
+	/**
+	 * @Route("/photoCollectionUpload/", name="_FormFlow_photoCollectionUpload")
+	 */
+	public function photoCollectionUploadAction() {
+		return $this->processFlow(new PhotoCollection(), $this->get(PhotoCollectionUploadFlow::class),
+			'@IntegrationTest/FormFlow/photoCollectionUpload.html.twig');
+	}
 
 	/**
 	 * @Route("/usualForm/", name="_FormFlow_usualForm")

--- a/Tests/IntegrationTestBundle/Controller/FormFlowController.php
+++ b/Tests/IntegrationTestBundle/Controller/FormFlowController.php
@@ -5,6 +5,7 @@ namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle\Controller;
 use Craue\FormFlowBundle\Form\FormFlow;
 use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Entity\Issue149Data;
 use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Entity\Issue64Data;
+use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Entity\PhotoCollection;
 use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Entity\PhotoUpload;
 use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Entity\RevalidatePreviousStepsData;
 use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Entity\Topic;
@@ -17,6 +18,7 @@ use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form\Issue87Flow;
 use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form\Issue149Flow;
 use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form\Issue303Flow;
 use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form\OnlyOneStepFlow;
+use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form\PhotoCollectionUploadFlow;
 use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form\PhotoUploadFlow;
 use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form\RemoveSecondStepSkipMarkOnResetFlow;
 use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form\RevalidatePreviousStepsFlow;
@@ -134,6 +136,14 @@ class FormFlowController extends AbstractController {
 		return $this->processFlow(new PhotoUpload(), $this->get(PhotoUploadFlow::class),
 				'@IntegrationTest/FormFlow/photoUpload.html.twig');
 	}
+
+    /**
+     * @Route("/photoCollectionUpload/", name="_FormFlow_photoCollectionUpload")
+     */
+    public function photoCollectionUploadAction() {
+        return $this->processFlow(new PhotoCollection(), $this->get(PhotoCollectionUploadFlow::class),
+            '@IntegrationTest/FormFlow/photoCollectionUpload.html.twig');
+    }
 
 	/**
 	 * @Route("/usualForm/", name="_FormFlow_usualForm")

--- a/Tests/IntegrationTestBundle/Entity/PhotoCollection.php
+++ b/Tests/IntegrationTestBundle/Entity/PhotoCollection.php
@@ -3,16 +3,14 @@
 namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @author Christian Raue <christian.raue@gmail.com>
  * @copyright 2011-2021 Christian Raue
  * @license http://opensource.org/licenses/mit-license.php MIT License
  */
-class PhotoCollection {
-
+class PhotoCollection
+{
 
 	public $photos;
 
@@ -21,12 +19,12 @@ class PhotoCollection {
 	 */
 	public $comment;
 
-    /**
-     * PhotoCollection constructor.
-     */
-    public function __construct()
-    {
-        $this->photos = new ArrayCollection([["photo" => null, "comment" => null]]);
-    }
+	/**
+	 * PhotoCollection constructor.
+	 */
+	public function __construct()
+	{
+		$this->photos = new ArrayCollection([["photo" => null, "comment" => null]]);
+	}
 
 }

--- a/Tests/IntegrationTestBundle/Entity/PhotoCollection.php
+++ b/Tests/IntegrationTestBundle/Entity/PhotoCollection.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2021 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class PhotoCollection {
+
+
+	public $photos;
+
+	/**
+	 * @var string
+	 */
+	public $comment;
+
+    /**
+     * PhotoCollection constructor.
+     */
+    public function __construct()
+    {
+        $this->photos = new ArrayCollection([["photo" => null, "comment" => null]]);
+    }
+
+}

--- a/Tests/IntegrationTestBundle/Form/PhotoCollectionUploadFlow.php
+++ b/Tests/IntegrationTestBundle/Form/PhotoCollectionUploadFlow.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form;
+
+use Craue\FormFlowBundle\Form\FormFlow;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2021 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class PhotoCollectionUploadFlow extends FormFlow {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function loadStepsConfig() {
+		$formType = PhotoCollectionUploadForm::class;
+
+		return [
+			[
+				'label' => 'select your photos',
+				'form_type' => $formType,
+			],
+			[
+				'label' => 'describe the photos',
+				'form_type' => $formType,
+			],
+			[
+				'label' => 'confirmation',
+				'form_type' => $formType,
+			],
+		];
+	}
+
+}

--- a/Tests/IntegrationTestBundle/Form/PhotoCollectionUploadForm.php
+++ b/Tests/IntegrationTestBundle/Form/PhotoCollectionUploadForm.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form;
+
+use Craue\FormFlowBundle\Tests\IntegrationTestBundle\Entity\PhotoUpload;
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2021 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class PhotoCollectionUploadForm extends AbstractType {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function buildForm(FormBuilderInterface $builder, array $options) {
+		switch ($options['flow_step']) {
+			case 1:
+				$builder->add('photos', CollectionType::class, [
+				    'entry_type' => PhotoCompleteUploadForm::class,
+                    'allow_add' => true,
+                ]);
+				break;
+			case 2:
+				$builder->add('comment', null, [
+					'required' => false,
+				]);
+				break;
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getBlockPrefix() {
+		return 'photoCollectionUpload';
+	}
+
+}

--- a/Tests/IntegrationTestBundle/Form/PhotoCollectionUploadForm.php
+++ b/Tests/IntegrationTestBundle/Form/PhotoCollectionUploadForm.php
@@ -24,9 +24,9 @@ class PhotoCollectionUploadForm extends AbstractType {
 		switch ($options['flow_step']) {
 			case 1:
 				$builder->add('photos', CollectionType::class, [
-				    'entry_type' => PhotoCompleteUploadForm::class,
-                    'allow_add' => true,
-                ]);
+					'entry_type' => PhotoCompleteUploadForm::class,
+					'allow_add' => true,
+				]);
 				break;
 			case 2:
 				$builder->add('comment', null, [

--- a/Tests/IntegrationTestBundle/Form/PhotoCompleteUploadForm.php
+++ b/Tests/IntegrationTestBundle/Form/PhotoCompleteUploadForm.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Craue\FormFlowBundle\Tests\IntegrationTestBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2021 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class PhotoCompleteUploadForm extends AbstractType {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function buildForm(FormBuilderInterface $builder, array $options) {
+        $builder->add('photo', FileType::class);
+        $builder->add('comment', null, [
+            'required' => false,
+        ]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getBlockPrefix() {
+		return 'photoCompleteUpload';
+	}
+
+}

--- a/Tests/IntegrationTestBundle/Form/PhotoCompleteUploadForm.php
+++ b/Tests/IntegrationTestBundle/Form/PhotoCompleteUploadForm.php
@@ -17,10 +17,10 @@ class PhotoCompleteUploadForm extends AbstractType {
 	 * {@inheritDoc}
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options) {
-        $builder->add('photo', FileType::class);
-        $builder->add('comment', null, [
-            'required' => false,
-        ]);
+		$builder->add('photo', FileType::class);
+		$builder->add('comment', null, [
+			'required' => false,
+		]);
 	}
 
 	/**

--- a/Tests/IntegrationTestBundle/Resources/views/FormFlow/photoCollectionUpload.html.twig
+++ b/Tests/IntegrationTestBundle/Resources/views/FormFlow/photoCollectionUpload.html.twig
@@ -1,0 +1,9 @@
+{% extends '@IntegrationTest/layout_flow.html.twig' %}
+
+{% block content %}
+	{{ parent() }}
+
+	{% if flow.getCurrentStepNumber() == 3 %}
+		<span id="rendered-images-count">{{ formData.photos | length }}</span>
+	{% endif %}
+{% endblock %}

--- a/Tests/IntegrationTestCase.php
+++ b/Tests/IntegrationTestCase.php
@@ -122,6 +122,14 @@ abstract class IntegrationTestCase extends WebTestCase {
 		$this->assertEquals($expectedSrcAttr, $this->getNodeAttribute('#rendered-image', 'src', $crawler));
 	}
 
+    /**
+     * @param string $expectedSrcAttr
+     * @param Crawler $crawler
+     */
+    protected function assertRenderedImageCollectionCount($expectedCount, Crawler $crawler) {
+        $this->assertEquals($expectedCount, $this->getNodeText("#rendered-images-count",  $crawler));
+    }
+
 	/**
 	 * @param string $expectedError
 	 * @param Crawler $crawler

--- a/Tests/PhotoUploadFlowTest.php
+++ b/Tests/PhotoUploadFlowTest.php
@@ -46,36 +46,36 @@ class PhotoUploadFlowTest extends IntegrationTestCase {
 		$this->assertRenderedImageUrl(sprintf('data:image/png;base64,%s', base64_encode(file_get_contents($image))), $crawler);
 	}
 
-    public function testPhotoInsideCollectionUpload() {
-        $image = __DIR__ . self::IMAGE;
+	public function testPhotoInsideCollectionUpload() {
+		$image = __DIR__ . self::IMAGE;
 
-        $crawler = static::$client->request('GET', $this->url('_FormFlow_photoCollectionUpload'));
-        $this->assertSame(200, static::$client->getResponse()->getStatusCode());
-        $this->assertCurrentStepNumber(1, $crawler);
-        $this->assertCurrentFormData('{"photos":{},"comment":null}', $crawler);
+		$crawler = static::$client->request('GET', $this->url('_FormFlow_photoCollectionUpload'));
+		$this->assertSame(200, static::$client->getResponse()->getStatusCode());
+		$this->assertCurrentStepNumber(1, $crawler);
+		$this->assertCurrentFormData('{"photos":{},"comment":null}', $crawler);
 
-        // upload the photo
-        $form = $crawler->selectButton('next')->form();
-        $form['photoCollectionUpload[photos][0][photo]']->upload($image);
-        $form['photoCollectionUpload[photos][0][comment]']->setValue("a beautiful image");
+		// upload the photo
+		$form = $crawler->selectButton('next')->form();
+		$form['photoCollectionUpload[photos][0][photo]']->upload($image);
+		$form['photoCollectionUpload[photos][0][comment]']->setValue("a beautiful image");
 
 
-        // allow the temporary file created by the DomCrawler to be removed after the test
-        $fileFieldValue = $form['photoCollectionUpload[photos][0][photo]']->getValue();
-        TempFileUtil::addTempFile($fileFieldValue['tmp_name']);
+		// allow the temporary file created by the DomCrawler to be removed after the test
+		$fileFieldValue = $form['photoCollectionUpload[photos][0][photo]']->getValue();
+		TempFileUtil::addTempFile($fileFieldValue['tmp_name']);
 
-        // submit the form -> step 2
-        $crawler = static::$client->submit($form);
-        $this->assertCurrentStepNumber(2, $crawler);
-        $this->assertCurrentFormData('{"photos":{},"comment":null}', $crawler);
+		// submit the form -> step 2
+		$crawler = static::$client->submit($form);
+		$this->assertCurrentStepNumber(2, $crawler);
+		$this->assertCurrentFormData('{"photos":{},"comment":null}', $crawler);
 
-        // comment -> step 3
-        $form = $crawler->selectButton('next')->form();
-        $crawler = static::$client->submit($form, [
-            'photoCollectionUpload[comment]' => 'blah',
-        ]);
-        $this->assertCurrentStepNumber(3, $crawler);
-        $this->assertCurrentFormData('{"photos":{},"comment":"blah"}', $crawler);
-        $this->assertRenderedImageCollectionCount(1, $crawler);
-    }
+		// comment -> step 3
+		$form = $crawler->selectButton('next')->form();
+		$crawler = static::$client->submit($form, [
+			'photoCollectionUpload[comment]' => 'blah',
+		]);
+		$this->assertCurrentStepNumber(3, $crawler);
+		$this->assertCurrentFormData('{"photos":{},"comment":"blah"}', $crawler);
+		$this->assertRenderedImageCollectionCount(1, $crawler);
+	}
 }

--- a/Tests/PhotoUploadFlowTest.php
+++ b/Tests/PhotoUploadFlowTest.php
@@ -46,4 +46,36 @@ class PhotoUploadFlowTest extends IntegrationTestCase {
 		$this->assertRenderedImageUrl(sprintf('data:image/png;base64,%s', base64_encode(file_get_contents($image))), $crawler);
 	}
 
+    public function testPhotoInsideCollectionUpload() {
+        $image = __DIR__ . self::IMAGE;
+
+        $crawler = static::$client->request('GET', $this->url('_FormFlow_photoCollectionUpload'));
+        $this->assertSame(200, static::$client->getResponse()->getStatusCode());
+        $this->assertCurrentStepNumber(1, $crawler);
+        $this->assertCurrentFormData('{"photos":{},"comment":null}', $crawler);
+
+        // upload the photo
+        $form = $crawler->selectButton('next')->form();
+        $form['photoCollectionUpload[photos][0][photo]']->upload($image);
+        $form['photoCollectionUpload[photos][0][comment]']->setValue("a beautiful image");
+
+
+        // allow the temporary file created by the DomCrawler to be removed after the test
+        $fileFieldValue = $form['photoCollectionUpload[photos][0][photo]']->getValue();
+        TempFileUtil::addTempFile($fileFieldValue['tmp_name']);
+
+        // submit the form -> step 2
+        $crawler = static::$client->submit($form);
+        $this->assertCurrentStepNumber(2, $crawler);
+        $this->assertCurrentFormData('{"photos":{},"comment":null}', $crawler);
+
+        // comment -> step 3
+        $form = $crawler->selectButton('next')->form();
+        $crawler = static::$client->submit($form, [
+            'photoCollectionUpload[comment]' => 'blah',
+        ]);
+        $this->assertCurrentStepNumber(3, $crawler);
+        $this->assertCurrentFormData('{"photos":{},"comment":"blah"}', $crawler);
+        $this->assertRenderedImageCollectionCount(1, $crawler);
+    }
 }


### PR DESCRIPTION
Entries inside a collection have numeric keys. Therefore files are appended, which creates new unwanted entries.

[array_merge_recursive](https://www.php.net/manual/en/function.array-merge-recursive.php) appends values to the first array if they have a numeric key.

[array_replace_recursive](https://www.php.net/manual/de/function.array-replace-recursive.php) behaves like array_merge_recursive but replaces numeric keys in the first array.