### PR TITLE
Fix deprecation

### DIFF
--- a/Form/FormFlow.php
+++ b/Form/FormFlow.php
@@ -523,7 +523,7 @@ abstract class FormFlow implements FormFlowInterface {
 
 	public function getRequestedTransition() {
 		if (empty($this->transition)) {
-			$this->transition = strtolower($this->getRequest()->request->get($this->getFormTransitionKey()));
+			$this->transition = strtolower($this->getRequest()->request->get($this->getFormTransitionKey(), ''));
 		}
 
 		return $this->transition;


### PR DESCRIPTION
Fixes the deprecation `strtolower(): Passing null to parameter #1 ($string) of type string is deprecated`

 when the form is initialized and the parameter does not exists