### PR TITLE
Remove dbal deprecations

### DIFF
--- a/Storage/DoctrineStorage.php
+++ b/Storage/DoctrineStorage.php
@@ -152,7 +152,7 @@ class DoctrineStorage implements StorageInterface {
 	private function createTable() {
 		$table = new Table(self::TABLE, [
 			new Column($this->keyColumn, Type::getType(Types::STRING), ['length' => 255]),
-			new Column($this->valueColumn, Type::getType(Types::ARRAY), ['length' => 255]),
+			new Column($this->valueColumn, Type::getType(Types::TEXT)),
 		]);
 
 		$table->setPrimaryKey([$this->keyColumn]);

--- a/Storage/DoctrineStorage.php
+++ b/Storage/DoctrineStorage.php
@@ -150,13 +150,9 @@ class DoctrineStorage implements StorageInterface {
 	}
 
 	private function createTable() {
-		// TODO remove as soon as Doctrine DBAL >= 3.0 is required
-		$stringType = defined('Doctrine\DBAL\Types\Types::STRING') ? Types::STRING : Type::STRING;
-		$arrayType = defined('Doctrine\DBAL\Types\Types::ARRAY') ? Types::ARRAY : Type::TARRAY;
-
 		$table = new Table(self::TABLE, [
-			new Column($this->keyColumn, Type::getType($stringType)),
-			new Column($this->valueColumn, Type::getType($arrayType)),
+			new Column($this->keyColumn, Type::getType(Types::STRING), ['length' => 255]),
+			new Column($this->valueColumn, Type::getType(Types::ARRAY), ['length' => 255]),
 		]);
 
 		$table->setPrimaryKey([$this->keyColumn]);

--- a/Tests/Storage/DoctrineStorageTest.php
+++ b/Tests/Storage/DoctrineStorageTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
+use Doctrine\DBAL\Tools\DsnParser;
 
 /**
  * @group unit
@@ -40,9 +41,17 @@ class DoctrineStorageTest extends AbstractStorageTest {
 			$this->markTestSkipped('Environment variable DB_DSN is not set.');
 		}
 
-		$this->conn = DriverManager::getConnection([
-			'url' => $_ENV['DB_DSN'],
-		], $configuration);
+		$dsn = $_ENV['DB_DSN'];
+		// TODO use DsnParser as soon as DBAL >= 3.6 is required
+		$params = class_exists(DsnParser::class)
+			? (new DsnParser([
+				'mysql'      => 'pdo_mysql',
+				'pgsql'      => 'pdo_pgsql',
+				'sqlite'     => 'pdo_sqlite',
+				]))->parse($dsn)
+			: ['url' => $dsn];
+
+		$this->conn = DriverManager::getConnection($params, $configuration);
 
 		$generator = $this->createMock(StorageKeyGeneratorInterface::class);
 

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
 		"craue/translations-tests": "^1.1",
 		"doctrine/collections": "^1.8 || ^2.1",
 		"doctrine/common": "^2.9 || ^3.0",
+		"doctrine/dbal": "^2.10 || ^3.0",
 		"doctrine/doctrine-bundle": "^1.10 || ^2.0",
 		"phpstan/extension-installer": "^1.1",
 		"phpstan/phpstan": "^1.10",
@@ -51,6 +52,9 @@
 		"symfony/phpunit-bridge": "^6.3",
 		"symfony/security-bundle": "^4.4 || ^5.4 || ^6.3",
 		"symfony/twig-bundle": "^4.4 || ^5.4 || ^6.3"
+	},
+	"conflict": {
+		"doctrine/dbal": "<2.10"
 	},
 	"minimum-stability": "stable",
 	"autoload": {

--- a/phpstan-config.neon
+++ b/phpstan-config.neon
@@ -63,10 +63,6 @@ parameters:
 		-
 			message: '#^Cannot call method fetchColumn\(\) on Doctrine\\DBAL\\Result\|int\|string\.$#'
 			path: Storage/DoctrineStorage.php
-		# TODO remove as soon as Doctrine DBAL >= 3.0 is required
-		-
-			message: '#^Access to undefined constant Doctrine\\DBAL\\Types\\Type::(STRING|TARRAY)\.$#'
-			path: Storage/DoctrineStorage.php
 		# TODO remove as soon as Doctrine DBAL >= 3.1 is required
 		-
 			message: "#^Call to function method_exists\\(\\) with Doctrine\\\\DBAL\\\\Connection and 'createSchemaManager' will always evaluate to true\\.$#"
@@ -76,11 +72,5 @@ parameters:
 			message: """
 				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
 				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			path: Storage/DoctrineStorage.php
-		-
-			message: """
-				#^Fetching deprecated class constant ARRAY of class Doctrine\\\\DBAL\\\\Types\\\\Types:
-				Use \\{@link Types::JSON} instead\\.$#
 			"""
 			path: Storage/DoctrineStorage.php


### PR DESCRIPTION
So the first commit uses MySQL for tests, then the second one requires explicitly `doctrine/dbal` (in dev and requires a minimum version for the users) as it is used in `DoctrineStorage` (I would also remove support for doctrine/dbal 2 since it's not maintained) and the third one changes `array` for `json` type dealing with the conversions.