### PR TITLE
Allow Symfony 7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
             php: '7.3'
             dependencies: lowest
           -
-            php: '8.2'
+            php: '8.3'
             dependencies: highest
           -
             php: '7.3'
@@ -54,8 +54,12 @@ jobs:
           -
             php: '8.2'
             symfony: '6.4.*'
-            stability: dev
-            allow-failure: true
+          -
+            php: '8.3'
+            symfony: '6.4.*'
+          -
+            php: '8.2'
+            symfony: '7.0.*'
 
     services:
       mysql:

--- a/Form/Extension/FormFlowFormExtension.php
+++ b/Form/Extension/FormFlowFormExtension.php
@@ -27,10 +27,7 @@ class FormFlowFormExtension extends AbstractTypeExtension {
 		return [FormType::class];
 	}
 
-	/**
-	 * @return void
-	 */
-	public function configureOptions(OptionsResolver $resolver) {
+	public function configureOptions(OptionsResolver $resolver): void {
 		$resolver->setDefined([
 			'flow_instance',
 			'flow_instance_key',
@@ -39,10 +36,7 @@ class FormFlowFormExtension extends AbstractTypeExtension {
 		]);
 	}
 
-	/**
-	 * @return void
-	 */
-	public function buildForm(FormBuilderInterface $builder, array $options) {
+	public function buildForm(FormBuilderInterface $builder, array $options): void {
 		if (array_key_exists('flow_instance', $options) && array_key_exists('flow_instance_key', $options)) {
 			$builder->add($options['flow_instance_key'], HiddenType::class, [
 				'data' => $options['flow_instance'],

--- a/Form/Extension/FormFlowHiddenFieldExtension.php
+++ b/Form/Extension/FormFlowHiddenFieldExtension.php
@@ -27,20 +27,14 @@ class FormFlowHiddenFieldExtension extends AbstractTypeExtension {
 		return [HiddenType::class];
 	}
 
-	/**
-	 * @return void
-	 */
-	public function configureOptions(OptionsResolver $resolver) {
+	public function configureOptions(OptionsResolver $resolver): void {
 		$resolver->setDefined([
 			'flow_instance_key',
 			'flow_step_key',
 		]);
 	}
 
-	/**
-	 * @return void
-	 */
-	public function finishView(FormView $view, FormInterface $form, array $options) {
+	public function finishView(FormView $view, FormInterface $form, array $options): void {
 		if (array_key_exists('flow_instance_key', $options) && $view->vars['name'] === $options['flow_instance_key']) {
 			$view->vars['value'] = $options['data'];
 			$view->vars['full_name'] = $options['flow_instance_key'];

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,17 @@
 	"homepage": "https://github.com/craue/CraueFormFlowBundle",
 	"require": {
 		"php": "^7.3 || ^8",
-		"symfony/config": "^4.4 || ^5.4 || ^6.3",
-		"symfony/dependency-injection": "^4.4 || ^5.4 || ^6.3",
-		"symfony/event-dispatcher": "^4.4 || ^5.4 || ^6.3",
-		"symfony/form": "^4.4 || ^5.4 || ^6.3",
-		"symfony/http-foundation": "^4.4 || ^5.4 || ^6.3",
-		"symfony/http-kernel": "^4.4 || ^5.4 || ^6.3",
-		"symfony/options-resolver": "^4.4 || ^5.4 || ^6.3",
-		"symfony/security-core": "^4.4 || ^5.4 || ^6.3",
-		"symfony/translation": "^4.4 || ^5.4 || ^6.3",
-		"symfony/validator": "^4.4 || ^5.4 || ^6.3",
-		"symfony/yaml": "^4.4 || ^5.4 || ^6.3"
+		"symfony/config": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/dependency-injection": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/event-dispatcher": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/form": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/http-foundation": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/http-kernel": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/options-resolver": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/security-core": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/translation": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/validator": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/yaml": "^4.4 || ^5.4 || ^6.3 || ^7.0"
 	},
 	"require-dev": {
 		"craue/translations-tests": "^1.1",
@@ -45,12 +45,12 @@
 		"phpstan/phpstan-strict-rules": "^1.1",
 		"phpstan/phpstan-symfony": "^1.1",
 		"phpunit/phpunit": "^9.5",
-		"symfony/browser-kit": "^4.4 || ^5.4 || ^6.3",
-		"symfony/css-selector": "^4.4 || ^5.4 || ^6.3",
-		"symfony/mime": "^4.4 || ^5.4 || ^6.3",
-		"symfony/phpunit-bridge": "^6.3",
-		"symfony/security-bundle": "^4.4 || ^5.4 || ^6.3",
-		"symfony/twig-bundle": "^4.4 || ^5.4 || ^6.3"
+		"symfony/browser-kit": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/css-selector": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/mime": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/phpunit-bridge": "^6.3 || ^7.0",
+		"symfony/security-bundle": "^4.4 || ^5.4 || ^6.3 || ^7.0",
+		"symfony/twig-bundle": "^4.4 || ^5.4 || ^6.3 || ^7.0"
 	},
 	"minimum-stability": "stable",
 	"autoload": {


### PR DESCRIPTION
Adding return type would be BC break for someone extending these files and overriding those method without adding the `void` return type, but I guess this is unlikely to happen, apparently these extension are not meant to be extended.

Closes #423